### PR TITLE
Fixed an error in the nomad plan

### DIFF
--- a/dp-api-router.nomad
+++ b/dp-api-router.nomad
@@ -1,4 +1,4 @@
-job "dp-code-list-api" {
+job "dp-api-router" {
   datacenters = ["eu-west-1"]
   region      = "eu"
   type        = "service"


### PR DESCRIPTION
The nomad plan contains the wrong task name. This should be dp-api-router