### PR TITLE
Add interceptor middleware to prepend any urls with environment host

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@ A service which routes API requests to the correct services. In the future this 
 | SEARCH_API_URL             | "http://localhost:23100"                  | A URL to the search api
 | API_POC_URL                | "http://localhost:3000"                   | A URL to the poc api
 | SHUTDOWN_TIMEOUT           | 5s                                        | The graceful shutdown timeout (`time.Duration` format)
+| ENV_HOST                   | "http://localhost:23200"                  | The public host for the environment the service is running on

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	RecipeAPIURL           string        `envconfig:"RECIPE_API_URL"`
 	ImportAPIURL           string        `envconfig:"IMPORT_API_URL"`
 	SearchAPIURL           string        `envconfig:"SEARCH_API_URL"`
+	EnvironmentHost        string        `envconfig:"ENV_HOST"`
 	APIPocURL              string        `envconfig:"API_POC_URL"`
 	GracefulShutdown       time.Duration `envconfig:"SHUTDOWN_TIMEOUT"`
 }
@@ -40,6 +41,7 @@ func Get() (*Config, error) {
 			ImportAPIURL:           "http://localhost:21800",
 			SearchAPIURL:           "http://localhost:23100",
 			APIPocURL:              "http://localhost:3000",
+			EnvironmentHost:        "http://localhost:23200",
 			GracefulShutdown:       5 * time.Second,
 		}
 		if err := envconfig.Process("", configuration); err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,6 +22,7 @@ func TestGetRetrunsDefaultValues(t *testing.T) {
 		So(configuration.ImportAPIURL, ShouldEqual, "http://localhost:21800")
 		So(configuration.SearchAPIURL, ShouldEqual, "http://localhost:23100")
 		So(configuration.APIPocURL, ShouldEqual, "http://localhost:3000")
+		So(configuration.EnvironmentHost, ShouldEqual, "http://localhost:23200")
 		So(configuration.GracefulShutdown, ShouldEqual, time.Second*5)
 	})
 }

--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -21,6 +21,15 @@ type writer struct {
 	domain string
 }
 
+// WriteHeader wraps the response writer WriteHeader method, but
+// removes the content length header so that the correct content
+// length is written when the response has been updated
+func (w writer) WriteHeader(code int) {
+	w.ResponseWriter.Header().Del("Content-Length")
+
+	w.ResponseWriter.WriteHeader(code)
+}
+
 // Write intercepts the response writer Write method, parses the json
 // and replaces any url domains with the environment host domain
 func (w writer) Write(b []byte) (int, error) {

--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -50,7 +50,8 @@ func (w writer) update(b []byte) ([]byte, error) {
 func (w writer) checkMap(document map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	if docLinks, ok := document[links].(map[string]interface{}); ok {
-		document[links], err = updateMap(docLinks, w.domain)
+		re := regexp.MustCompile(`^(.+:\/\/)(.+$)`)
+		document[links], err = updateMap(docLinks, re.ReplaceAllString(w.domain, "${1}api.${2}"))
 		if err != nil {
 			return nil, err
 		}
@@ -65,7 +66,8 @@ func (w writer) checkMap(document map[string]interface{}) (map[string]interface{
 	}
 
 	if docDimensions, ok := document[dimensions].([]interface{}); ok {
-		document[dimensions], err = updateArray(docDimensions, w.domain)
+		re := regexp.MustCompile(`^(.+:\/\/)(.+$)`)
+		document[dimensions], err = updateArray(docDimensions, re.ReplaceAllString(w.domain, "${1}api.${2}"))
 		if err != nil {
 			return nil, err
 		}

--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -16,6 +16,10 @@ const (
 	href = "href"
 )
 
+var (
+	re = regexp.MustCompile(`^(.+:\/\/)(.+$)`)
+)
+
 type writer struct {
 	http.ResponseWriter
 	domain string
@@ -58,8 +62,8 @@ func (w writer) update(b []byte) ([]byte, error) {
 
 func (w writer) checkMap(document map[string]interface{}) (map[string]interface{}, error) {
 	var err error
+
 	if docLinks, ok := document[links].(map[string]interface{}); ok {
-		re := regexp.MustCompile(`^(.+:\/\/)(.+$)`)
 		document[links], err = updateMap(docLinks, re.ReplaceAllString(w.domain, "${1}api.${2}"))
 		if err != nil {
 			return nil, err
@@ -67,7 +71,6 @@ func (w writer) checkMap(document map[string]interface{}) (map[string]interface{
 	}
 
 	if docDownloads, ok := document[downloads].(map[string]interface{}); ok {
-		re := regexp.MustCompile(`^(.+:\/\/)(.+$)`)
 		document[downloads], err = updateMap(docDownloads, re.ReplaceAllString(w.domain, "${1}download.${2}"))
 		if err != nil {
 			return nil, err
@@ -75,7 +78,6 @@ func (w writer) checkMap(document map[string]interface{}) (map[string]interface{
 	}
 
 	if docDimensions, ok := document[dimensions].([]interface{}); ok {
-		re := regexp.MustCompile(`^(.+:\/\/)(.+$)`)
 		document[dimensions], err = updateArray(docDimensions, re.ReplaceAllString(w.domain, "${1}api.${2}"))
 		if err != nil {
 			return nil, err

--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -109,14 +109,21 @@ func (w writer) checkMap(document map[string]interface{}) (map[string]interface{
 func updateMap(docMap map[string]interface{}, domain string) (map[string]interface{}, error) {
 	var err error
 	for k, v := range docMap {
-		val := v.(map[string]interface{})
-		if field, ok := val[href].(string); ok {
-			val[href], err = getLink(field, domain)
+		if val, ok := v.(map[string]interface{}); ok {
+			if field, ok := val[href].(string); ok {
+				val[href], err = getLink(field, domain)
+				if err != nil {
+					return nil, err
+				}
+			}
+			docMap[k] = val
+		}
+		if val, ok := v.([]interface{}); ok {
+			docMap[k], err = updateArray(val, domain)
 			if err != nil {
 				return nil, err
 			}
 		}
-		docMap[k] = val
 	}
 	return docMap, nil
 }

--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -1,0 +1,146 @@
+package interceptor
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+)
+
+const (
+	links      = "links"
+	dimensions = "dimensions"
+	downloads  = "downloads"
+
+	href = "href"
+)
+
+type writer struct {
+	http.ResponseWriter
+	domain string
+}
+
+// Write intercepts the response writer Write method, parses the json
+// and replaces any url domains with the environment host domain
+func (w writer) Write(b []byte) (int, error) {
+	b, err := w.update(b)
+	if err != nil {
+		return 0, err
+	}
+
+	return w.ResponseWriter.Write(b)
+}
+
+func (w writer) update(b []byte) ([]byte, error) {
+	var err error
+	document := make(map[string]interface{})
+	if err = json.Unmarshal(b, &document); err != nil {
+		return nil, err
+	}
+
+	document, err = w.checkMap(document)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(document)
+}
+
+func (w writer) checkMap(document map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	if docLinks, ok := document[links].(map[string]interface{}); ok {
+		document[links], err = updateMap(docLinks, w.domain)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if docDownloads, ok := document[downloads].(map[string]interface{}); ok {
+		re := regexp.MustCompile(`^(.+:\/\/)(.+$)`)
+		document[downloads], err = updateMap(docDownloads, re.ReplaceAllString(w.domain, "${1}download.${2}"))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if docDimensions, ok := document[dimensions].([]interface{}); ok {
+		document[dimensions], err = updateArray(docDimensions, w.domain)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for k, v := range document {
+		if subDocument, ok := v.(map[string]interface{}); ok {
+			document[k], err = w.checkMap(subDocument)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		if items, ok := v.([]interface{}); ok {
+			for i, subVal := range items {
+				if subValMap, ok := subVal.(map[string]interface{}); ok {
+					items[i], err = w.checkMap(subValMap)
+					if err != nil {
+						return nil, err
+					}
+				}
+			}
+			document[k] = items
+		}
+	}
+
+	return document, nil
+}
+
+func updateMap(docMap map[string]interface{}, domain string) (map[string]interface{}, error) {
+	var err error
+	for k, v := range docMap {
+		val := v.(map[string]interface{})
+		if field, ok := val[href].(string); ok {
+			val[href], err = getLink(field, domain)
+			if err != nil {
+				return nil, err
+			}
+		}
+		docMap[k] = val
+	}
+	return docMap, nil
+}
+
+func updateArray(docArray []interface{}, domain string) ([]interface{}, error) {
+	var err error
+	for i, v := range docArray {
+		if val, ok := v.(map[string]interface{}); ok {
+			if field, ok := val[href].(string); ok {
+				val[href], err = getLink(field, domain)
+				if err != nil {
+					return nil, err
+				}
+			}
+			docArray[i] = val
+		}
+	}
+	return docArray, nil
+}
+
+// Handler takes a given domain to handle the intercepting of http requests with the
+// purpose of prepending any api response urls with the correct domain for the environment
+func Handler(domain string) func(http.Handler) http.Handler {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			h.ServeHTTP(writer{w, domain}, req)
+		})
+	}
+}
+
+func getLink(field, domain string) (string, error) {
+	uri, err := url.Parse(field)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s%s", domain, uri.Path), nil
+}

--- a/interceptor/interceptor_test.go
+++ b/interceptor/interceptor_test.go
@@ -1,0 +1,73 @@
+package interceptor
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestUnitInterceptor(t *testing.T) {
+	Convey("test interceptor correctly updates a href in links subdoc", t, func() {
+		testJSON := `{"links":{"self":{"href":"/datasets/12345"}}}`
+		respW := httptest.NewRecorder()
+
+		w := writer{respW, "https://beta.ons.gov.uk"}
+
+		n, err := w.Write([]byte(testJSON))
+		So(err, ShouldBeNil)
+		So(n, ShouldEqual, 68)
+
+		So(respW.Body.String(), ShouldEqual, `{"links":{"self":{"href":"https://beta.ons.gov.uk/datasets/12345"}}}`)
+	})
+
+	Convey("test interceptor correctly updates a href in downloads subdoc", t, func() {
+		testJSON := `{"downloads":{"csv":{"href":"http://localhost:22000/myfile.csv"}}}`
+		respW := httptest.NewRecorder()
+
+		w := writer{respW, "https://beta.ons.gov.uk"}
+
+		n, err := w.Write([]byte(testJSON))
+		So(err, ShouldBeNil)
+		So(n, ShouldEqual, 76)
+
+		So(respW.Body.String(), ShouldEqual, `{"downloads":{"csv":{"href":"https://download.beta.ons.gov.uk/myfile.csv"}}}`)
+	})
+
+	Convey("test interceptor correctly updates a href in dimensions subdoc", t, func() {
+		testJSON := `{"dimensions":[{"href":"http://localhost:23000/codelists/1234567"}]}`
+		respW := httptest.NewRecorder()
+
+		w := writer{respW, "https://beta.ons.gov.uk"}
+
+		n, err := w.Write([]byte(testJSON))
+		So(err, ShouldBeNil)
+		So(n, ShouldEqual, 69)
+
+		So(respW.Body.String(), ShouldEqual, `{"dimensions":[{"href":"https://beta.ons.gov.uk/codelists/1234567"}]}`)
+	})
+
+	Convey("test interceptor correctly updates a nested links document", t, func() {
+		testJSON := `{"items":[{"links":{"self":{"href":"/datasets/12345"}}}]}`
+		respW := httptest.NewRecorder()
+
+		w := writer{respW, "https://beta.ons.gov.uk"}
+
+		n, err := w.Write([]byte(testJSON))
+		So(err, ShouldBeNil)
+		So(n, ShouldEqual, 80)
+
+		So(respW.Body.String(), ShouldEqual, `{"items":[{"links":{"self":{"href":"https://beta.ons.gov.uk/datasets/12345"}}}]}`)
+	})
+
+	Convey("test interceptor returns an error on write if bytes are not valid json", t, func() {
+		b := `not valid json sorry ¯\_(ツ)_/¯`
+		respW := httptest.NewRecorder()
+
+		w := writer{respW, "https://beta.ons.gov.uk"}
+
+		n, err := w.Write([]byte(b))
+		So(err, ShouldNotBeNil)
+		So(n, ShouldEqual, 0)
+	})
+}

--- a/interceptor/interceptor_test.go
+++ b/interceptor/interceptor_test.go
@@ -62,6 +62,19 @@ func TestUnitInterceptor(t *testing.T) {
 		So(respW.Body.String(), ShouldEqual, `{"items":[{"links":{"self":{"href":"https://api.beta.ons.gov.uk/datasets/12345"}}}]}`)
 	})
 
+	Convey("test interceptor correctly updates a nested array of links", t, func() {
+		testJSON := `{"links":{"instances":[{"href":"/datasets/12345"}]}}`
+		respW := httptest.NewRecorder()
+
+		w := writer{respW, testDomain}
+
+		n, err := w.Write([]byte(testJSON))
+		So(err, ShouldBeNil)
+		So(n, ShouldEqual, 79)
+
+		So(respW.Body.String(), ShouldEqual, `{"links":{"instances":[{"href":"https://api.beta.ons.gov.uk/datasets/12345"}]}}`)
+	})
+
 	Convey("test interceptor returns an error on write if bytes are not valid json", t, func() {
 		b := `not valid json sorry ¯\_(ツ)_/¯`
 		respW := httptest.NewRecorder()

--- a/interceptor/interceptor_test.go
+++ b/interceptor/interceptor_test.go
@@ -7,25 +7,27 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+const testDomain = "https://beta.ons.gov.uk"
+
 func TestUnitInterceptor(t *testing.T) {
 	Convey("test interceptor correctly updates a href in links subdoc", t, func() {
 		testJSON := `{"links":{"self":{"href":"/datasets/12345"}}}`
 		respW := httptest.NewRecorder()
 
-		w := writer{respW, "https://beta.ons.gov.uk"}
+		w := writer{respW, testDomain}
 
 		n, err := w.Write([]byte(testJSON))
 		So(err, ShouldBeNil)
-		So(n, ShouldEqual, 68)
+		So(n, ShouldEqual, 72)
 
-		So(respW.Body.String(), ShouldEqual, `{"links":{"self":{"href":"https://beta.ons.gov.uk/datasets/12345"}}}`)
+		So(respW.Body.String(), ShouldEqual, `{"links":{"self":{"href":"https://api.beta.ons.gov.uk/datasets/12345"}}}`)
 	})
 
 	Convey("test interceptor correctly updates a href in downloads subdoc", t, func() {
 		testJSON := `{"downloads":{"csv":{"href":"http://localhost:22000/myfile.csv"}}}`
 		respW := httptest.NewRecorder()
 
-		w := writer{respW, "https://beta.ons.gov.uk"}
+		w := writer{respW, testDomain}
 
 		n, err := w.Write([]byte(testJSON))
 		So(err, ShouldBeNil)
@@ -38,33 +40,33 @@ func TestUnitInterceptor(t *testing.T) {
 		testJSON := `{"dimensions":[{"href":"http://localhost:23000/codelists/1234567"}]}`
 		respW := httptest.NewRecorder()
 
-		w := writer{respW, "https://beta.ons.gov.uk"}
+		w := writer{respW, testDomain}
 
 		n, err := w.Write([]byte(testJSON))
 		So(err, ShouldBeNil)
-		So(n, ShouldEqual, 69)
+		So(n, ShouldEqual, 73)
 
-		So(respW.Body.String(), ShouldEqual, `{"dimensions":[{"href":"https://beta.ons.gov.uk/codelists/1234567"}]}`)
+		So(respW.Body.String(), ShouldEqual, `{"dimensions":[{"href":"https://api.beta.ons.gov.uk/codelists/1234567"}]}`)
 	})
 
 	Convey("test interceptor correctly updates a nested links document", t, func() {
 		testJSON := `{"items":[{"links":{"self":{"href":"/datasets/12345"}}}]}`
 		respW := httptest.NewRecorder()
 
-		w := writer{respW, "https://beta.ons.gov.uk"}
+		w := writer{respW, testDomain}
 
 		n, err := w.Write([]byte(testJSON))
 		So(err, ShouldBeNil)
-		So(n, ShouldEqual, 80)
+		So(n, ShouldEqual, 84)
 
-		So(respW.Body.String(), ShouldEqual, `{"items":[{"links":{"self":{"href":"https://beta.ons.gov.uk/datasets/12345"}}}]}`)
+		So(respW.Body.String(), ShouldEqual, `{"items":[{"links":{"self":{"href":"https://api.beta.ons.gov.uk/datasets/12345"}}}]}`)
 	})
 
 	Convey("test interceptor returns an error on write if bytes are not valid json", t, func() {
 		b := `not valid json sorry ¯\_(ツ)_/¯`
 		respW := httptest.NewRecorder()
 
-		w := writer{respW, "https://beta.ons.gov.uk"}
+		w := writer{respW, testDomain}
 
 		n, err := w.Write([]byte(b))
 		So(err, ShouldNotBeNil)

--- a/main.go
+++ b/main.go
@@ -5,10 +5,12 @@ import (
 	"os"
 
 	"github.com/ONSdigital/dp-api-router/config"
+	"github.com/ONSdigital/dp-api-router/interceptor"
 	"github.com/ONSdigital/dp-api-router/proxy"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/ONSdigital/go-ns/server"
 	"github.com/gorilla/mux"
+	"github.com/justinas/alice"
 )
 
 func addVersionHandler(router *mux.Router, proxy *proxy.APIProxy, path string) {
@@ -60,7 +62,9 @@ func main() {
 	addLegacyHandler(router, poc, "/timeseries")
 	addLegacyHandler(router, poc, "/search")
 
-	httpServer := server.New(cfg.BindAddr, router)
+	alice := alice.New(interceptor.Handler(cfg.EnvironmentHost)).Then(router)
+
+	httpServer := server.New(cfg.BindAddr, alice)
 	httpServer.DefaultShutdownTimeout = cfg.GracefulShutdown
 	err = httpServer.ListenAndServe()
 	if err != nil {


### PR DESCRIPTION
### What

- Add interceptor middleware to prepend any urls with environment host

### How to test

- Set the environment variable `export ENV_HOST=https://beta.ons.gov.uk"`
- Request a valid version through the api router:

`curl -v http://localhost:23200/v1/datasets/{id}/editions/{edition}/versions/{version} | jq`

- Verify that the links, dimensions and download hrefs all contain the environment domain with either api. / download. correctly prefixed.

### Who can review

Team B