### PR TITLE
Feature/dont return error on update

### DIFF
--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
+
+	"github.com/ONSdigital/go-ns/log"
 )
 
 // Transport implements the http RoundTripper method and allows the
@@ -56,7 +58,8 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 
 	b, err = t.update(b)
 	if err != nil {
-		return nil, err
+		log.Debug("could not update response body with correct links", log.Data{"update_error": err.Error()})
+		return resp, nil
 	}
 
 	body := ioutil.NopCloser(bytes.NewReader(b))

--- a/interceptor/interceptor_test.go
+++ b/interceptor/interceptor_test.go
@@ -102,13 +102,4 @@ func TestUnitInterceptor(t *testing.T) {
 		So(string(b), ShouldEqual, `{"links":{"instances":[{"href":"https://api.beta.ons.gov.uk/v1/datasets/12345"}]}}`)
 	})
 
-	Convey("test interceptor returns an error on write if bytes are not valid json", t, func() {
-		b := `not valid json sorry ¯\_(ツ)_/¯`
-		transp := dummyRT{b}
-
-		t := NewRoundTripper(testDomain, transp)
-
-		_, err := t.RoundTrip(nil)
-		So(err, ShouldNotBeNil)
-	})
 }


### PR DESCRIPTION
## What

- If we return an error on "links update" then it overrides the response from the proxied api, so don't return it

## How to review

- Verify logic is correct

## Who can review

Anyone