### PR TITLE
added feature flag for enable/disable cmd routes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,7 +11,7 @@ import (
 type Config struct {
 	BindAddr               string        `envconfig:"BIND_ADDR"`
 	Version                string        `envconfig:"VERSION"`
-	EnableCmdRoutes        bool          `envconfig:"ENABLE_CMD_ROUTES"`
+	EnableV1Routes         bool          `envconfig:"ENABLE_V1_ROUTES"`
 	EnablePrivateEndpoints bool          `envconfig:"ENABLE_PRIVATE_ENDPOINTS"`
 	HierarchyAPIURL        string        `envconfig:"HIERARCHY_API_URL"`
 	FilterAPIURL           string        `envconfig:"FILTER_API_URL"`
@@ -34,8 +34,8 @@ func Get() (*Config, error) {
 		configuration = &Config{
 			BindAddr:               ":23200",
 			Version:                "v1",
-			EnableCmdRoutes:        true,
 			EnablePrivateEndpoints: true,
+			EnableV1Routes:         false,
 			HierarchyAPIURL:        "http://localhost:22600",
 			FilterAPIURL:           "http://localhost:22100",
 			DatasetAPIURL:          "http://localhost:22000",

--- a/config/config.go
+++ b/config/config.go
@@ -11,7 +11,7 @@ import (
 type Config struct {
 	BindAddr               string        `envconfig:"BIND_ADDR"`
 	Version                string        `envconfig:"VERSION"`
-	EnableV1Endpoints      bool          `envconfig:"ENABLE_V1_ROUTES"`
+	EnableV1Endpoints      bool          `envconfig:"ENABLE_V1_ENDPOINTS"`
 	EnablePrivateEndpoints bool          `envconfig:"ENABLE_PRIVATE_ENDPOINTS"`
 	HierarchyAPIURL        string        `envconfig:"HIERARCHY_API_URL"`
 	FilterAPIURL           string        `envconfig:"FILTER_API_URL"`

--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ import (
 type Config struct {
 	BindAddr               string        `envconfig:"BIND_ADDR"`
 	Version                string        `envconfig:"VERSION"`
+	EnableCmdRoutes        bool          `envconfig:"ENABLE_CMD_ROUTES"`
 	EnablePrivateEndpoints bool          `envconfig:"ENABLE_PRIVATE_ENDPOINTS"`
 	HierarchyAPIURL        string        `envconfig:"HIERARCHY_API_URL"`
 	FilterAPIURL           string        `envconfig:"FILTER_API_URL"`
@@ -33,6 +34,7 @@ func Get() (*Config, error) {
 		configuration = &Config{
 			BindAddr:               ":23200",
 			Version:                "v1",
+			EnableCmdRoutes:        true,
 			EnablePrivateEndpoints: true,
 			HierarchyAPIURL:        "http://localhost:22600",
 			FilterAPIURL:           "http://localhost:22100",

--- a/config/config.go
+++ b/config/config.go
@@ -11,7 +11,7 @@ import (
 type Config struct {
 	BindAddr               string        `envconfig:"BIND_ADDR"`
 	Version                string        `envconfig:"VERSION"`
-	EnableV1Routes         bool          `envconfig:"ENABLE_V1_ROUTES"`
+	EnableV1Endpoints      bool          `envconfig:"ENABLE_V1_ROUTES"`
 	EnablePrivateEndpoints bool          `envconfig:"ENABLE_PRIVATE_ENDPOINTS"`
 	HierarchyAPIURL        string        `envconfig:"HIERARCHY_API_URL"`
 	FilterAPIURL           string        `envconfig:"FILTER_API_URL"`
@@ -35,7 +35,7 @@ func Get() (*Config, error) {
 			BindAddr:               ":23200",
 			Version:                "v1",
 			EnablePrivateEndpoints: true,
-			EnableV1Routes:         false,
+			EnableV1Endpoints:      false,
 			HierarchyAPIURL:        "http://localhost:22600",
 			FilterAPIURL:           "http://localhost:22100",
 			DatasetAPIURL:          "http://localhost:22000",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -15,7 +15,7 @@ func TestGetRetrunsDefaultValues(t *testing.T) {
 		So(configuration.BindAddr, ShouldEqual, ":23200")
 		So(configuration.Version, ShouldEqual, "v1")
 		So(configuration.EnablePrivateEndpoints, ShouldEqual, true)
-		So(configuration.EnableV1Routes, ShouldEqual, false)
+		So(configuration.EnableV1Endpoints, ShouldEqual, false)
 		So(configuration.HierarchyAPIURL, ShouldEqual, "http://localhost:22600")
 		So(configuration.FilterAPIURL, ShouldEqual, "http://localhost:22100")
 		So(configuration.DatasetAPIURL, ShouldEqual, "http://localhost:22000")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -15,6 +15,7 @@ func TestGetRetrunsDefaultValues(t *testing.T) {
 		So(configuration.BindAddr, ShouldEqual, ":23200")
 		So(configuration.Version, ShouldEqual, "v1")
 		So(configuration.EnablePrivateEndpoints, ShouldEqual, true)
+		So(configuration.EnableV1Routes, ShouldEqual, false)
 		So(configuration.HierarchyAPIURL, ShouldEqual, "http://localhost:22600")
 		So(configuration.FilterAPIURL, ShouldEqual, "http://localhost:22100")
 		So(configuration.DatasetAPIURL, ShouldEqual, "http://localhost:22000")

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func main() {
 	router := mux.NewRouter()
 
 	// legacy API
-	if cfg.EnableCmdRoutes {
+	if cfg.EnableV1Routes {
 
 		log.Info("routing to cmd endpoints has been enabled ....", nil)
 

--- a/main.go
+++ b/main.go
@@ -32,10 +32,9 @@ func main() {
 	log.Info("starting dp-api-router ....", log.Data{"config": cfg})
 	router := mux.NewRouter()
 
-	// legacy API
 	if cfg.EnableV1Endpoints {
 
-		log.Info("routing to cmd endpoints has been enabled ....", nil)
+		log.Info("routing to v1 endpoints has been enabled", nil)
 
 		// Public APIs
 		codeList := proxy.NewAPIProxy(cfg.CodelistAPIURL, cfg.Version, cfg.EnvironmentHost, "")
@@ -59,9 +58,10 @@ func main() {
 			addVersionHandler(router, dataset, "/instances")
 		}
 	} else {
-		log.Info("routing to cmd endpoints has NOT been enabled ....", nil)
+		log.Info("routing to v1 endpoints has been disabled", nil)
 	}
 
+	// legacy API
 	poc := proxy.NewAPIProxy(cfg.APIPocURL, "", cfg.EnvironmentHost, "")
 	addLegacyHandler(router, poc, "/ops")
 	addLegacyHandler(router, poc, "/dataset")

--- a/main.go
+++ b/main.go
@@ -32,29 +32,36 @@ func main() {
 	log.Info("starting dp-api-router ....", log.Data{"config": cfg})
 	router := mux.NewRouter()
 
-	// Public APIs
-	codeList := proxy.NewAPIProxy(cfg.CodelistAPIURL, cfg.Version, cfg.EnvironmentHost, "")
-	dataset := proxy.NewAPIProxy(cfg.DatasetAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL)
-	filter := proxy.NewAPIProxy(cfg.FilterAPIURL, cfg.Version, cfg.EnvironmentHost, "")
-	hierarchy := proxy.NewAPIProxy(cfg.HierarchyAPIURL, cfg.Version, cfg.EnvironmentHost, "")
-	search := proxy.NewAPIProxy(cfg.SearchAPIURL, cfg.Version, cfg.EnvironmentHost, "")
-	addVersionHandler(router, codeList, "/code-lists")
-	addVersionHandler(router, dataset, "/datasets")
-	addVersionHandler(router, filter, "/filters")
-	addVersionHandler(router, filter, "/filter-outputs")
-	addVersionHandler(router, hierarchy, "/hierarchies")
-	addVersionHandler(router, search, "/search")
+	// legacy API
+	if cfg.EnableCmdRoutes {
 
-	// Private APIs
-	if cfg.EnablePrivateEndpoints {
-		recipe := proxy.NewAPIProxy(cfg.RecipeAPIURL, cfg.Version, cfg.EnvironmentHost, "")
-		importAPI := proxy.NewAPIProxy(cfg.ImportAPIURL, cfg.Version, cfg.EnvironmentHost, "")
-		addVersionHandler(router, recipe, "/recipes")
-		addVersionHandler(router, importAPI, "/jobs")
-		addVersionHandler(router, dataset, "/instances")
+		log.Info("routing to cmd endpoints has been enabled ....", nil)
+
+		// Public APIs
+		codeList := proxy.NewAPIProxy(cfg.CodelistAPIURL, cfg.Version, cfg.EnvironmentHost, "")
+		dataset := proxy.NewAPIProxy(cfg.DatasetAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL)
+		filter := proxy.NewAPIProxy(cfg.FilterAPIURL, cfg.Version, cfg.EnvironmentHost, "")
+		hierarchy := proxy.NewAPIProxy(cfg.HierarchyAPIURL, cfg.Version, cfg.EnvironmentHost, "")
+		search := proxy.NewAPIProxy(cfg.SearchAPIURL, cfg.Version, cfg.EnvironmentHost, "")
+		addVersionHandler(router, codeList, "/code-lists")
+		addVersionHandler(router, dataset, "/datasets")
+		addVersionHandler(router, filter, "/filters")
+		addVersionHandler(router, filter, "/filter-outputs")
+		addVersionHandler(router, hierarchy, "/hierarchies")
+		addVersionHandler(router, search, "/search")
+
+		// Private APIs
+		if cfg.EnablePrivateEndpoints {
+			recipe := proxy.NewAPIProxy(cfg.RecipeAPIURL, cfg.Version, cfg.EnvironmentHost, "")
+			importAPI := proxy.NewAPIProxy(cfg.ImportAPIURL, cfg.Version, cfg.EnvironmentHost, "")
+			addVersionHandler(router, recipe, "/recipes")
+			addVersionHandler(router, importAPI, "/jobs")
+			addVersionHandler(router, dataset, "/instances")
+		}
+	} else {
+		log.Info("routing to cmd endpoints has NOT been enabled ....", nil)
 	}
 
-	// legacy API
 	poc := proxy.NewAPIProxy(cfg.APIPocURL, "", cfg.EnvironmentHost, "")
 	addLegacyHandler(router, poc, "/ops")
 	addLegacyHandler(router, poc, "/dataset")

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func main() {
 	router := mux.NewRouter()
 
 	// legacy API
-	if cfg.EnableV1Routes {
+	if cfg.EnableV1Endpoints {
 
 		log.Info("routing to cmd endpoints has been enabled ....", nil)
 


### PR DESCRIPTION
### What

Added a feature flag so we can choose between enabling routes to everything or just the legacy/existing website apis (so we can deploy this in advance of the rest of cmd).

Note - **DO NOT DEPLOY** until all the secrets are updated and apps redeployed as v1 endpoints are disabled by default.

### How to review

Sanity check

### Who can review

Anyone