### PR TITLE
Feature/404 cmd endpoints

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,7 +11,7 @@ import (
 type Config struct {
 	BindAddr               string        `envconfig:"BIND_ADDR"`
 	Version                string        `envconfig:"VERSION"`
-	EnableV1Endpoints      bool          `envconfig:"ENABLE_V1_ENDPOINTS"`
+	EnableV1BetaRestriction      bool          `envconfig:"ENABLE_V1_ENDPOINTS"`
 	EnablePrivateEndpoints bool          `envconfig:"ENABLE_PRIVATE_ENDPOINTS"`
 	HierarchyAPIURL        string        `envconfig:"HIERARCHY_API_URL"`
 	FilterAPIURL           string        `envconfig:"FILTER_API_URL"`
@@ -36,7 +36,7 @@ func Get() (*Config, error) {
 			BindAddr:               ":23200",
 			Version:                "v1",
 			EnablePrivateEndpoints: true,
-			EnableV1Endpoints:      false,
+			EnableV1BetaRestriction: false,
 			HierarchyAPIURL:        "http://localhost:22600",
 			FilterAPIURL:           "http://localhost:22100",
 			DatasetAPIURL:          "http://localhost:22000",

--- a/config/config.go
+++ b/config/config.go
@@ -9,22 +9,22 @@ import (
 
 // Config contains configurable details for running the service
 type Config struct {
-	BindAddr               string        `envconfig:"BIND_ADDR"`
-	Version                string        `envconfig:"VERSION"`
-	EnableV1BetaRestriction      bool          `envconfig:"ENABLE_V1_ENDPOINTS"`
-	EnablePrivateEndpoints bool          `envconfig:"ENABLE_PRIVATE_ENDPOINTS"`
-	HierarchyAPIURL        string        `envconfig:"HIERARCHY_API_URL"`
-	FilterAPIURL           string        `envconfig:"FILTER_API_URL"`
-	DatasetAPIURL          string        `envconfig:"DATASET_API_URL"`
-	CodelistAPIURL         string        `envconfig:"CODE_LIST_API_URL"`
-	RecipeAPIURL           string        `envconfig:"RECIPE_API_URL"`
-	ImportAPIURL           string        `envconfig:"IMPORT_API_URL"`
-	SearchAPIURL           string        `envconfig:"SEARCH_API_URL"`
-	ContextURL             string        `envconfig:"CONTEXT_URL"`
-	EnvironmentHost        string        `envconfig:"ENV_HOST"`
-	APIPocURL              string        `envconfig:"API_POC_URL"`
-	GracefulShutdown       time.Duration `envconfig:"SHUTDOWN_TIMEOUT"`
-	AllowedOrigins         []string      `envconfig:"ALLOWED_ORIGINS"`
+	BindAddr                string        `envconfig:"BIND_ADDR"`
+	Version                 string        `envconfig:"VERSION"`
+	EnableV1BetaRestriction bool          `envconfig:"ENABLE_V1_BETA_RESTRICTION"`
+	EnablePrivateEndpoints  bool          `envconfig:"ENABLE_PRIVATE_ENDPOINTS"`
+	HierarchyAPIURL         string        `envconfig:"HIERARCHY_API_URL"`
+	FilterAPIURL            string        `envconfig:"FILTER_API_URL"`
+	DatasetAPIURL           string        `envconfig:"DATASET_API_URL"`
+	CodelistAPIURL          string        `envconfig:"CODE_LIST_API_URL"`
+	RecipeAPIURL            string        `envconfig:"RECIPE_API_URL"`
+	ImportAPIURL            string        `envconfig:"IMPORT_API_URL"`
+	SearchAPIURL            string        `envconfig:"SEARCH_API_URL"`
+	ContextURL              string        `envconfig:"CONTEXT_URL"`
+	EnvironmentHost         string        `envconfig:"ENV_HOST"`
+	APIPocURL               string        `envconfig:"API_POC_URL"`
+	GracefulShutdown        time.Duration `envconfig:"SHUTDOWN_TIMEOUT"`
+	AllowedOrigins          []string      `envconfig:"ALLOWED_ORIGINS"`
 }
 
 var configuration *Config
@@ -33,22 +33,22 @@ var configuration *Config
 func Get() (*Config, error) {
 	if configuration == nil {
 		configuration = &Config{
-			BindAddr:               ":23200",
-			Version:                "v1",
-			EnablePrivateEndpoints: true,
+			BindAddr:                ":23200",
+			Version:                 "v1",
+			EnablePrivateEndpoints:  true,
 			EnableV1BetaRestriction: false,
-			HierarchyAPIURL:        "http://localhost:22600",
-			FilterAPIURL:           "http://localhost:22100",
-			DatasetAPIURL:          "http://localhost:22000",
-			CodelistAPIURL:         "http://localhost:22400",
-			RecipeAPIURL:           "http://localhost:22300",
-			ImportAPIURL:           "http://localhost:21800",
-			SearchAPIURL:           "http://localhost:23100",
-			APIPocURL:              "http://localhost:3000",
-			ContextURL:             "",
-			EnvironmentHost:        "http://localhost:23200",
-			GracefulShutdown:       5 * time.Second,
-			AllowedOrigins:         []string{"https://publishing.ons.gov.uk"},
+			HierarchyAPIURL:         "http://localhost:22600",
+			FilterAPIURL:            "http://localhost:22100",
+			DatasetAPIURL:           "http://localhost:22000",
+			CodelistAPIURL:          "http://localhost:22400",
+			RecipeAPIURL:            "http://localhost:22300",
+			ImportAPIURL:            "http://localhost:21800",
+			SearchAPIURL:            "http://localhost:23100",
+			APIPocURL:               "http://localhost:3000",
+			ContextURL:              "",
+			EnvironmentHost:         "http://localhost:23200",
+			GracefulShutdown:        5 * time.Second,
+			AllowedOrigins:          []string{"https://publishing.ons.gov.uk"},
 		}
 		if err := envconfig.Process("", configuration); err != nil {
 			log.ErrorC("failed to parse configuration", err, log.Data{"config": configuration})

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -15,7 +15,7 @@ func TestGetRetrunsDefaultValues(t *testing.T) {
 		So(configuration.BindAddr, ShouldEqual, ":23200")
 		So(configuration.Version, ShouldEqual, "v1")
 		So(configuration.EnablePrivateEndpoints, ShouldEqual, true)
-		So(configuration.EnableV1Endpoints, ShouldEqual, false)
+		So(configuration.EnableV1BetaRestriction, ShouldEqual, false)
 		So(configuration.HierarchyAPIURL, ShouldEqual, "http://localhost:22600")
 		So(configuration.FilterAPIURL, ShouldEqual, "http://localhost:22100")
 		So(configuration.DatasetAPIURL, ShouldEqual, "http://localhost:22000")

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ func main() {
 	router := mux.NewRouter()
 
 	if cfg.EnableV1BetaRestriction {
-		log.Info("beta route restiction is active, /v1 api request will only be permitted aginst beta domains", nil)
+		log.Info("beta route restiction is active, /v1 api requests will only be permitted aginst beta domains", nil)
 	}
 
 	// Public APIs

--- a/main.go
+++ b/main.go
@@ -34,9 +34,7 @@ func main() {
 	router := mux.NewRouter()
 
 	if cfg.EnableV1BetaRestriction {
-		log.Info("routing to v1 endpoints has been enabled", nil)
-	} else {
-		log.Info("routing to v1 endpoints has been disabled", nil)
+		log.Info("beta route restiction is active, /v1 api request will only be permitted aginst beta domains", nil)
 	}
 
 	// Public APIs

--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ func main() {
 	}
 
 	// legacy API
-	poc := proxy.NewAPIProxy(cfg.APIPocURL, "", cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	poc := proxy.NewAPIProxy(cfg.APIPocURL, "", cfg.EnvironmentHost, "", false)
 	addLegacyHandler(router, poc, "/ops")
 	addLegacyHandler(router, poc, "/dataset")
 	addLegacyHandler(router, poc, "/timeseries")

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ func main() {
 	router := mux.NewRouter()
 
 	if cfg.EnableV1BetaRestriction {
-		log.Info("beta route restiction is active, /v1 api requests will only be permitted aginst beta domains", nil)
+		log.Info("beta route restiction is active, /v1 api requests will only be permitted against beta domains", nil)
 	}
 
 	// Public APIs

--- a/main.go
+++ b/main.go
@@ -33,37 +33,36 @@ func main() {
 	log.Info("starting dp-api-router ....", log.Data{"config": cfg})
 	router := mux.NewRouter()
 
-	if cfg.EnableV1Endpoints {
-
+	if cfg.EnableV1BetaRestriction {
 		log.Info("routing to v1 endpoints has been enabled", nil)
-
-		// Public APIs
-		codeList := proxy.NewAPIProxy(cfg.CodelistAPIURL, cfg.Version, cfg.EnvironmentHost, "")
-		dataset := proxy.NewAPIProxy(cfg.DatasetAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL)
-		filter := proxy.NewAPIProxy(cfg.FilterAPIURL, cfg.Version, cfg.EnvironmentHost, "")
-		hierarchy := proxy.NewAPIProxy(cfg.HierarchyAPIURL, cfg.Version, cfg.EnvironmentHost, "")
-		search := proxy.NewAPIProxy(cfg.SearchAPIURL, cfg.Version, cfg.EnvironmentHost, "")
-		addVersionHandler(router, codeList, "/code-lists")
-		addVersionHandler(router, dataset, "/datasets")
-		addVersionHandler(router, filter, "/filters")
-		addVersionHandler(router, filter, "/filter-outputs")
-		addVersionHandler(router, hierarchy, "/hierarchies")
-		addVersionHandler(router, search, "/search")
-
-		// Private APIs
-		if cfg.EnablePrivateEndpoints {
-			recipe := proxy.NewAPIProxy(cfg.RecipeAPIURL, cfg.Version, cfg.EnvironmentHost, "")
-			importAPI := proxy.NewAPIProxy(cfg.ImportAPIURL, cfg.Version, cfg.EnvironmentHost, "")
-			addVersionHandler(router, recipe, "/recipes")
-			addVersionHandler(router, importAPI, "/jobs")
-			addVersionHandler(router, dataset, "/instances")
-		}
 	} else {
 		log.Info("routing to v1 endpoints has been disabled", nil)
 	}
 
+	// Public APIs
+	codeList := proxy.NewAPIProxy(cfg.CodelistAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	dataset := proxy.NewAPIProxy(cfg.DatasetAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
+	filter := proxy.NewAPIProxy(cfg.FilterAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	hierarchy := proxy.NewAPIProxy(cfg.HierarchyAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	search := proxy.NewAPIProxy(cfg.SearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	addVersionHandler(router, codeList, "/code-lists")
+	addVersionHandler(router, dataset, "/datasets")
+	addVersionHandler(router, filter, "/filters")
+	addVersionHandler(router, filter, "/filter-outputs")
+	addVersionHandler(router, hierarchy, "/hierarchies")
+	addVersionHandler(router, search, "/search")
+
+	// Private APIs
+	if cfg.EnablePrivateEndpoints {
+		recipe := proxy.NewAPIProxy(cfg.RecipeAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+		importAPI := proxy.NewAPIProxy(cfg.ImportAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+		addVersionHandler(router, recipe, "/recipes")
+		addVersionHandler(router, importAPI, "/jobs")
+		addVersionHandler(router, dataset, "/instances")
+	}
+
 	// legacy API
-	poc := proxy.NewAPIProxy(cfg.APIPocURL, "", cfg.EnvironmentHost, "")
+	poc := proxy.NewAPIProxy(cfg.APIPocURL, "", cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	addLegacyHandler(router, poc, "/ops")
 	addLegacyHandler(router, poc, "/dataset")
 	addLegacyHandler(router, poc, "/timeseries")

--- a/middleware/beta.go
+++ b/middleware/beta.go
@@ -7,11 +7,11 @@ import (
 )
 
 // BetaApiHandler will return a 404 where enforceBetaRoutes is true and the request is aimed at a non beta domain
-func BetaApiHandler(enforceBetaRoutes bool, h http.Handler) http.Handler {
+func BetaApiHandler(enableBetaRestriction bool, h http.Handler) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
-		if enforceBetaRoutes && !strings.HasPrefix(r.Host, "api.beta") {
+		if enableBetaRestriction && !strings.HasPrefix(r.Host, "api.beta") {
 
 			log.InfoCtx(r.Context(), "beta endpoint requested via a non beta domain, returning 404",
 				log.Data{"url": r.URL.String()})

--- a/middleware/beta.go
+++ b/middleware/beta.go
@@ -1,0 +1,25 @@
+package middleware
+
+import (
+	"github.com/ONSdigital/go-ns/log"
+	"net/http"
+	"strings"
+)
+
+// BetaApiHandler will return a 404 where enforceBetaRoutes is true and the request is aimed at a non beta domain
+func BetaApiHandler(enforceBetaRoutes bool, h http.Handler) http.Handler {
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		if enforceBetaRoutes && !strings.HasPrefix(r.Host, "api.beta") {
+
+			log.InfoCtx(r.Context(), "beta endpoint requested via a non beta domain, returning 404",
+				log.Data{"url": r.URL.String()})
+
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		h.ServeHTTP(w, r)
+	})
+}

--- a/middleware/beta_test.go
+++ b/middleware/beta_test.go
@@ -18,54 +18,54 @@ func TestBetaHandler_WraperHandler(t *testing.T) {
 
 func TestBetaHandler_RestrictionEnabled(t *testing.T) {
 
-		Convey("a request to a beta domain should return 200 status ok", t, func() {
-			req, err := http.NewRequest("GET", "/", nil)
-			if err != nil {
-				t.Fail()
-			}
+	Convey("a request to a beta domain should return 200 status ok", t, func() {
+		req, err := http.NewRequest("GET", "/", nil)
+		if err != nil {
+			t.Fail()
+		}
 
-			req.Host = "api.beta"
+		req.Host = "api.beta"
 
-			w := httptest.NewRecorder()
-			wrapped := BetaApiHandler(true, dummyHandler)
+		w := httptest.NewRecorder()
+		wrapped := BetaApiHandler(true, dummyHandler)
 
-			wrapped.ServeHTTP(w, req)
-			So(w.Code, ShouldEqual, 200)
+		wrapped.ServeHTTP(w, req)
+		So(w.Code, ShouldEqual, 200)
 
-		})
+	})
 
-		Convey("a request to a non beta domain should return 404 status not found", t, func() {
-			req, err := http.NewRequest("GET", "/", nil)
-			if err != nil {
-				t.Fail()
-			}
+	Convey("a request to a non beta domain should return 404 status not found", t, func() {
+		req, err := http.NewRequest("GET", "/", nil)
+		if err != nil {
+			t.Fail()
+		}
 
-			req.Host = "api.not.beta"
+		req.Host = "api.not.beta"
 
-			w := httptest.NewRecorder()
-			wrapped := BetaApiHandler(true, dummyHandler)
+		w := httptest.NewRecorder()
+		wrapped := BetaApiHandler(true, dummyHandler)
 
-			wrapped.ServeHTTP(w, req)
-			So(w.Code, ShouldEqual, 404)
+		wrapped.ServeHTTP(w, req)
+		So(w.Code, ShouldEqual, 404)
 
-		})
+	})
 }
 
 func TestBetaHandler_RestrictionNotEnabled(t *testing.T) {
 
-		Convey("a request to a non beta domain should return 200 status ok", t, func() {
-			req, err := http.NewRequest("GET", "/", nil)
-			if err != nil {
-				t.Fail()
-			}
+	Convey("a request to a non beta domain should return 200 status ok", t, func() {
+		req, err := http.NewRequest("GET", "/", nil)
+		if err != nil {
+			t.Fail()
+		}
 
-			req.Host = "api.beta"
+		req.Host = "api.beta"
 
-			w := httptest.NewRecorder()
-			wrapped := BetaApiHandler(false, dummyHandler)
+		w := httptest.NewRecorder()
+		wrapped := BetaApiHandler(false, dummyHandler)
 
-			wrapped.ServeHTTP(w, req)
-			So(w.Code, ShouldEqual, 200)
+		wrapped.ServeHTTP(w, req)
+		So(w.Code, ShouldEqual, 200)
 
-		})
+	})
 }

--- a/middleware/beta_test.go
+++ b/middleware/beta_test.go
@@ -35,9 +35,7 @@ func TestBetaHandler(t *testing.T) {
 
 		Convey("a request to a non beta domain should return 404 status not found", func() {
 			req, err := http.NewRequest("GET", "/", nil)
-			if err != nil {
-				t.Fail()
-			}
+			So(err, ShouldBeNil)
 
 			req.Host = "api.not.beta"
 

--- a/middleware/beta_test.go
+++ b/middleware/beta_test.go
@@ -1,0 +1,71 @@
+package middleware
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"net/http"
+	"net/http/httptest"
+)
+
+func TestBetaHandler_WraperHandler(t *testing.T) {
+
+	Convey("beta handler should wrap another handler", t, func() {
+		wrapped := BetaApiHandler(true, dummyHandler)
+		So(wrapped, ShouldHaveSameTypeAs, dummyHandler)
+	})
+}
+
+func TestBetaHandler_RestrictionEnabled(t *testing.T) {
+
+		Convey("a request to a beta domain should return 200 status ok", t, func() {
+			req, err := http.NewRequest("GET", "/", nil)
+			if err != nil {
+				t.Fail()
+			}
+
+			req.Host = "api.beta"
+
+			w := httptest.NewRecorder()
+			wrapped := BetaApiHandler(true, dummyHandler)
+
+			wrapped.ServeHTTP(w, req)
+			So(w.Code, ShouldEqual, 200)
+
+		})
+
+		Convey("a request to a non beta domain should return 404 status not found", t, func() {
+			req, err := http.NewRequest("GET", "/", nil)
+			if err != nil {
+				t.Fail()
+			}
+
+			req.Host = "api.not.beta"
+
+			w := httptest.NewRecorder()
+			wrapped := BetaApiHandler(true, dummyHandler)
+
+			wrapped.ServeHTTP(w, req)
+			So(w.Code, ShouldEqual, 404)
+
+		})
+}
+
+func TestBetaHandler_RestrictionNotEnabled(t *testing.T) {
+
+		Convey("a request to a non beta domain should return 200 status ok", t, func() {
+			req, err := http.NewRequest("GET", "/", nil)
+			if err != nil {
+				t.Fail()
+			}
+
+			req.Host = "api.beta"
+
+			w := httptest.NewRecorder()
+			wrapped := BetaApiHandler(false, dummyHandler)
+
+			wrapped.ServeHTTP(w, req)
+			So(w.Code, ShouldEqual, 200)
+
+		})
+}

--- a/middleware/beta_test.go
+++ b/middleware/beta_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 )
 
-func TestBetaHandler_WraperHandler(t *testing.T) {
+func TestBetaHandler(t *testing.T) {
 
 	Convey("beta handler should wrap another handler", t, func() {
 		wrapped := BetaApiHandler(true, dummyHandler)

--- a/middleware/beta_test.go
+++ b/middleware/beta_test.go
@@ -14,58 +14,58 @@ func TestBetaHandler_WraperHandler(t *testing.T) {
 		wrapped := BetaApiHandler(true, dummyHandler)
 		So(wrapped, ShouldHaveSameTypeAs, dummyHandler)
 	})
-}
 
-func TestBetaHandler_RestrictionEnabled(t *testing.T) {
+	Convey("where beta restrictions are enabled", t, func() {
 
-	Convey("a request to a beta domain should return 200 status ok", t, func() {
-		req, err := http.NewRequest("GET", "/", nil)
-		if err != nil {
-			t.Fail()
-		}
+		Convey("a request to a beta domain should return 200 status ok", func() {
+			req, err := http.NewRequest("GET", "/", nil)
+			if err != nil {
+				t.Fail()
+			}
 
-		req.Host = "api.beta"
+			req.Host = "api.beta"
 
-		w := httptest.NewRecorder()
-		wrapped := BetaApiHandler(true, dummyHandler)
+			w := httptest.NewRecorder()
+			wrapped := BetaApiHandler(true, dummyHandler)
 
-		wrapped.ServeHTTP(w, req)
-		So(w.Code, ShouldEqual, 200)
+			wrapped.ServeHTTP(w, req)
+			So(w.Code, ShouldEqual, 200)
 
+		})
+
+		Convey("a request to a non beta domain should return 404 status not found", func() {
+			req, err := http.NewRequest("GET", "/", nil)
+			if err != nil {
+				t.Fail()
+			}
+
+			req.Host = "api.not.beta"
+
+			w := httptest.NewRecorder()
+			wrapped := BetaApiHandler(true, dummyHandler)
+
+			wrapped.ServeHTTP(w, req)
+			So(w.Code, ShouldEqual, 404)
+
+		})
 	})
 
-	Convey("a request to a non beta domain should return 404 status not found", t, func() {
-		req, err := http.NewRequest("GET", "/", nil)
-		if err != nil {
-			t.Fail()
-		}
+	Convey("where beta restrictions are not enabled", t, func() {
 
-		req.Host = "api.not.beta"
+		Convey("a request to a non beta domain should return 200 status ok", func() {
+			req, err := http.NewRequest("GET", "/", nil)
+			if err != nil {
+				t.Fail()
+			}
 
-		w := httptest.NewRecorder()
-		wrapped := BetaApiHandler(true, dummyHandler)
+			req.Host = "api.not.beta"
 
-		wrapped.ServeHTTP(w, req)
-		So(w.Code, ShouldEqual, 404)
+			w := httptest.NewRecorder()
+			wrapped := BetaApiHandler(false, dummyHandler)
 
-	})
-}
+			wrapped.ServeHTTP(w, req)
+			So(w.Code, ShouldEqual, 200)
 
-func TestBetaHandler_RestrictionNotEnabled(t *testing.T) {
-
-	Convey("a request to a non beta domain should return 200 status ok", t, func() {
-		req, err := http.NewRequest("GET", "/", nil)
-		if err != nil {
-			t.Fail()
-		}
-
-		req.Host = "api.beta"
-
-		w := httptest.NewRecorder()
-		wrapped := BetaApiHandler(false, dummyHandler)
-
-		wrapped.ServeHTTP(w, req)
-		So(w.Code, ShouldEqual, 200)
-
+		})
 	})
 }

--- a/middleware/beta_test.go
+++ b/middleware/beta_test.go
@@ -19,9 +19,7 @@ func TestBetaHandler(t *testing.T) {
 
 		Convey("a request to a beta domain should return 200 status ok", func() {
 			req, err := http.NewRequest("GET", "/", nil)
-			if err != nil {
-				t.Fail()
-			}
+			So(err, ShouldBeNil)
 
 			req.Host = "api.beta"
 
@@ -52,9 +50,7 @@ func TestBetaHandler(t *testing.T) {
 
 		Convey("a request to a non beta domain should return 200 status ok", func() {
 			req, err := http.NewRequest("GET", "/", nil)
-			if err != nil {
-				t.Fail()
-			}
+			So(err, ShouldBeNil)
 
 			req.Host = "api.not.beta"
 

--- a/middleware/origin.go
+++ b/middleware/origin.go
@@ -1,8 +1,8 @@
 package middleware
 
 import (
-	"net/http"
 	"github.com/ONSdigital/go-ns/log"
+	"net/http"
 )
 
 // SetAllowOriginHeader sets the 'Access-Control-Allow-Origin' field for origin domains we allow. Otherwise returning a 401.
@@ -22,7 +22,7 @@ func SetAllowOriginHeader(allowedOrigins []string) func(h http.Handler) http.Han
 
 			if acceptedOrigin == "" {
 				log.InfoCtx(r.Context(), "request received but origin not allowed, returning 401",
-					log.Data{"origin": origin, "allowed_origins":allowedOrigins})
+					log.Data{"origin": origin, "allowed_origins": allowedOrigins})
 				w.WriteHeader(http.StatusUnauthorized)
 				return
 			}

--- a/middleware/origin.go
+++ b/middleware/origin.go
@@ -1,6 +1,9 @@
 package middleware
 
-import "net/http"
+import (
+	"net/http"
+	"github.com/ONSdigital/go-ns/log"
+)
 
 // SetAllowOriginHeader sets the 'Access-Control-Allow-Origin' field for origin domains we allow. Otherwise returning a 401.
 func SetAllowOriginHeader(allowedOrigins []string) func(h http.Handler) http.Handler {
@@ -18,6 +21,8 @@ func SetAllowOriginHeader(allowedOrigins []string) func(h http.Handler) http.Han
 			}
 
 			if acceptedOrigin == "" {
+				log.InfoCtx(r.Context(), "request received but origin not allowed, returning 401",
+					log.Data{"origin": origin, "allowed_origins":allowedOrigins})
 				w.WriteHeader(http.StatusUnauthorized)
 				return
 			}

--- a/middleware/origin_test.go
+++ b/middleware/origin_test.go
@@ -35,7 +35,7 @@ func TestOriginHandler(t *testing.T) {
 		req.Header.Set("Origin", whiteListedOrigin1)
 		w := httptest.NewRecorder()
 
-		handler := SetAllowOriginHeader([]string(whiteListedOrigins))
+		handler := SetAllowOriginHeader(whiteListedOrigins)
 		wrapped := handler(dummyHandler)
 
 		wrapped.ServeHTTP(w, req)

--- a/middleware/origin_test.go
+++ b/middleware/origin_test.go
@@ -14,7 +14,7 @@ const (
 )
 
 var (
-	dummyHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {})
+	dummyHandler       = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {})
 	whiteListedOrigins = []string{whiteListedOrigin1, whiteListedOrigin2}
 )
 

--- a/middleware/origin_test.go
+++ b/middleware/origin_test.go
@@ -28,9 +28,7 @@ func TestOriginHandler(t *testing.T) {
 
 	Convey("origin handler should serve the request where the origin is allowed", t, func() {
 		req, err := http.NewRequest("GET", "/", nil)
-		if err != nil {
-			t.Fail()
-		}
+		So(err, ShouldBeNil)
 
 		req.Header.Set("Origin", whiteListedOrigin1)
 		w := httptest.NewRecorder()
@@ -46,9 +44,7 @@ func TestOriginHandler(t *testing.T) {
 
 	Convey("origin handler should return 401 unauthorised where origin is not allowed", t, func() {
 		req, err := http.NewRequest("GET", "/", nil)
-		if err != nil {
-			t.Fail()
-		}
+		So(err, ShouldBeNil)
 
 		req.Header.Set("Origin", whiteListedOrigin1)
 		w := httptest.NewRecorder()

--- a/middleware/origin_test.go
+++ b/middleware/origin_test.go
@@ -1,0 +1,63 @@
+package middleware
+
+import (
+	"net/http"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"net/http/httptest"
+)
+
+const (
+	whiteListedOrigin1 = "i-r-a-good-place.com"
+	whiteListedOrigin2 = "is-a-better-place.fam"
+)
+
+var (
+	dummyHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {})
+	whiteListedOrigins = []string{whiteListedOrigin1, whiteListedOrigin2}
+)
+
+func TestOriginHandler(t *testing.T) {
+
+	Convey("origin handler should wrap another handler", t, func() {
+		handler := SetAllowOriginHeader([]string{"origin-is-allowed.com"})
+		wrapped := handler(dummyHandler)
+		So(wrapped, ShouldHaveSameTypeAs, dummyHandler)
+	})
+
+	Convey("origin handler should serve the request where the origin is allowed", t, func() {
+		req, err := http.NewRequest("GET", "/", nil)
+		if err != nil {
+			t.Fail()
+		}
+
+		req.Header.Set("Origin", whiteListedOrigin1)
+		w := httptest.NewRecorder()
+
+		handler := SetAllowOriginHeader([]string(whiteListedOrigins))
+		wrapped := handler(dummyHandler)
+
+		wrapped.ServeHTTP(w, req)
+		So(w.Code, ShouldEqual, 200)
+		So(w.Header().Get("Access-Control-Allow-Origin"), ShouldEqual, whiteListedOrigin1)
+
+	})
+
+	Convey("origin handler should return 401 unauthorised where origin is not allowed", t, func() {
+		req, err := http.NewRequest("GET", "/", nil)
+		if err != nil {
+			t.Fail()
+		}
+
+		req.Header.Set("Origin", whiteListedOrigin1)
+		w := httptest.NewRecorder()
+
+		handler := SetAllowOriginHeader([]string{})
+		wrapped := handler(dummyHandler)
+
+		wrapped.ServeHTTP(w, req)
+		So(w.Code, ShouldEqual, 401)
+	})
+
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -13,13 +13,13 @@ import (
 
 // APIProxy will forward any requests to a API
 type APIProxy struct {
-	target            *url.URL
-	proxy             *httputil.ReverseProxy
-	Version           string
-	enforceBetaRoutes bool
+	target                *url.URL
+	proxy                 *httputil.ReverseProxy
+	Version               string
+	enableBetaRestriction bool
 }
 
-func NewAPIProxy(target, version, envHost, contextURL string, enforceBetaRoutes bool) *APIProxy {
+func NewAPIProxy(target, version, envHost, contextURL string, enableBetaRestriction bool) *APIProxy {
 	targetURL, err := url.Parse(target)
 	if err != nil {
 		log.ErrorC("failed to create url", err, log.Data{"url": target})
@@ -30,10 +30,10 @@ func NewAPIProxy(target, version, envHost, contextURL string, enforceBetaRoutes 
 	pxy.Transport = interceptor.NewRoundTripper(envHost+"/"+version, contextURL, http.DefaultTransport)
 
 	return &APIProxy{
-		target:            targetURL,
-		proxy:             pxy,
-		Version:           version,
-		enforceBetaRoutes: enforceBetaRoutes}
+		target:                targetURL,
+		proxy:                 pxy,
+		Version:               version,
+		enableBetaRestriction: enableBetaRestriction}
 }
 
 func (p *APIProxy) Handle(w http.ResponseWriter, r *http.Request) {
@@ -43,5 +43,5 @@ func (p *APIProxy) Handle(w http.ResponseWriter, r *http.Request) {
 func (p *APIProxy) VersionHandle(w http.ResponseWriter, r *http.Request) {
 	r.URL.Path = strings.Replace(r.URL.Path, "/v1", "", 1)
 
-	middleware.BetaApiHandler(p.enforceBetaRoutes, p.proxy).ServeHTTP(w, r)
+	middleware.BetaApiHandler(p.enableBetaRestriction, p.proxy).ServeHTTP(w, r)
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1,24 +1,25 @@
 package proxy
 
 import (
+	"github.com/ONSdigital/dp-api-router/interceptor"
+	"github.com/ONSdigital/dp-api-router/middleware"
+	"github.com/ONSdigital/go-ns/log"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"os"
 	"strings"
-
-	"github.com/ONSdigital/dp-api-router/interceptor"
-	"github.com/ONSdigital/go-ns/log"
 )
 
 // APIProxy will forward any requests to a API
 type APIProxy struct {
-	target  *url.URL
-	proxy   *httputil.ReverseProxy
-	Version string
+	target            *url.URL
+	proxy             *httputil.ReverseProxy
+	Version           string
+	enforceBetaRoutes bool
 }
 
-func NewAPIProxy(target, version, envHost, contextURL string) *APIProxy {
+func NewAPIProxy(target, version, envHost, contextURL string, enforceBetaRoutes bool) *APIProxy {
 	targetURL, err := url.Parse(target)
 	if err != nil {
 		log.ErrorC("failed to create url", err, log.Data{"url": target})
@@ -29,9 +30,10 @@ func NewAPIProxy(target, version, envHost, contextURL string) *APIProxy {
 	pxy.Transport = interceptor.NewRoundTripper(envHost+"/"+version, contextURL, http.DefaultTransport)
 
 	return &APIProxy{
-		target:  targetURL,
-		proxy:   pxy,
-		Version: version}
+		target:            targetURL,
+		proxy:             pxy,
+		Version:           version,
+		enforceBetaRoutes: enforceBetaRoutes}
 }
 
 func (p *APIProxy) Handle(w http.ResponseWriter, r *http.Request) {
@@ -41,5 +43,5 @@ func (p *APIProxy) Handle(w http.ResponseWriter, r *http.Request) {
 func (p *APIProxy) VersionHandle(w http.ResponseWriter, r *http.Request) {
 	r.URL.Path = strings.Replace(r.URL.Path, "/v1", "", 1)
 
-	p.proxy.ServeHTTP(w, r)
+	middleware.BetaApiHandler(p.enforceBetaRoutes, p.proxy).ServeHTTP(w, r)
 }


### PR DESCRIPTION
### What

Added feature flag so we can restrict access (return 404) to requests made against v1/cmd endpoints on a non-beta domain.

this: https://trello.com/c/nvdg4Wpu/4018-update-api-router-to-404-for-cmd-end-points-on-apionsgov

Also added some additional logging and unit tests for the CORS origin handler.

### How to review

Sanity check, run the tests.

### Who can review

Anyone