### PR TITLE
updated origin handler and default allowed origins

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -48,7 +48,6 @@ func Get() (*Config, error) {
 			ContextURL:              "",
 			EnvironmentHost:         "http://localhost:23200",
 			GracefulShutdown:        5 * time.Second,
-			AllowedOrigins:          []string{},
 		}
 		if err := envconfig.Process("", configuration); err != nil {
 			log.ErrorC("failed to parse configuration", err, log.Data{"config": configuration})

--- a/config/config.go
+++ b/config/config.go
@@ -48,7 +48,7 @@ func Get() (*Config, error) {
 			ContextURL:              "",
 			EnvironmentHost:         "http://localhost:23200",
 			GracefulShutdown:        5 * time.Second,
-			AllowedOrigins: []string{},
+			AllowedOrigins:          []string{},
 		}
 		if err := envconfig.Process("", configuration); err != nil {
 			log.ErrorC("failed to parse configuration", err, log.Data{"config": configuration})

--- a/config/config.go
+++ b/config/config.go
@@ -48,12 +48,12 @@ func Get() (*Config, error) {
 			ContextURL:              "",
 			EnvironmentHost:         "http://localhost:23200",
 			GracefulShutdown:        5 * time.Second,
-			AllowedOrigins:          []string{
-										"https://publishing.ons.gov.uk",
-										"https://publishing.develop.onsdigital.co.uk",
-										"https://publishing.production.onsdigital.co.uk",
-										"https://publishing.cmd.onsdigital.co.uk",
-										"https://publishing.cmd-dev.onsdigital.co.uk"},
+			AllowedOrigins: []string{
+				"https://publishing.ons.gov.uk",
+				"https://publishing.develop.onsdigital.co.uk",
+				"https://publishing.production.onsdigital.co.uk",
+				"https://publishing.cmd.onsdigital.co.uk",
+				"https://publishing.cmd-dev.onsdigital.co.uk"},
 		}
 		if err := envconfig.Process("", configuration); err != nil {
 			log.ErrorC("failed to parse configuration", err, log.Data{"config": configuration})

--- a/config/config.go
+++ b/config/config.go
@@ -48,7 +48,12 @@ func Get() (*Config, error) {
 			ContextURL:              "",
 			EnvironmentHost:         "http://localhost:23200",
 			GracefulShutdown:        5 * time.Second,
-			AllowedOrigins:          []string{"https://publishing.ons.gov.uk"},
+			AllowedOrigins:          []string{
+										"https://publishing.ons.gov.uk",
+										"https://publishing.develop.onsdigital.co.uk",
+										"https://publishing.production.onsdigital.co.uk",
+										"https://publishing.cmd.onsdigital.co.uk",
+										"https://publishing.cmd-dev.onsdigital.co.uk"},
 		}
 		if err := envconfig.Process("", configuration); err != nil {
 			log.ErrorC("failed to parse configuration", err, log.Data{"config": configuration})

--- a/config/config.go
+++ b/config/config.go
@@ -48,12 +48,7 @@ func Get() (*Config, error) {
 			ContextURL:              "",
 			EnvironmentHost:         "http://localhost:23200",
 			GracefulShutdown:        5 * time.Second,
-			AllowedOrigins: []string{
-				"https://publishing.ons.gov.uk",
-				"https://publishing.develop.onsdigital.co.uk",
-				"https://publishing.production.onsdigital.co.uk",
-				"https://publishing.cmd.onsdigital.co.uk",
-				"https://publishing.cmd-dev.onsdigital.co.uk"},
+			AllowedOrigins: []string{},
 		}
 		if err := envconfig.Process("", configuration); err != nil {
 			log.ErrorC("failed to parse configuration", err, log.Data{"config": configuration})

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,6 +25,5 @@ func TestGetRetrunsDefaultValues(t *testing.T) {
 		So(configuration.APIPocURL, ShouldEqual, "http://localhost:3000")
 		So(configuration.EnvironmentHost, ShouldEqual, "http://localhost:23200")
 		So(configuration.GracefulShutdown, ShouldEqual, time.Second*5)
-		So(configuration.AllowedOrigins, ShouldEqual, []string{})
 	})
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,6 +25,6 @@ func TestGetRetrunsDefaultValues(t *testing.T) {
 		So(configuration.APIPocURL, ShouldEqual, "http://localhost:3000")
 		So(configuration.EnvironmentHost, ShouldEqual, "http://localhost:23200")
 		So(configuration.GracefulShutdown, ShouldEqual, time.Second*5)
-		So(configuration.AllowedOrigins, ShouldBeBlank)
+		So(configuration.AllowedOrigins, ShouldEqual, []string{})
 	})
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,6 +25,6 @@ func TestGetRetrunsDefaultValues(t *testing.T) {
 		So(configuration.APIPocURL, ShouldEqual, "http://localhost:3000")
 		So(configuration.EnvironmentHost, ShouldEqual, "http://localhost:23200")
 		So(configuration.GracefulShutdown, ShouldEqual, time.Second*5)
-		So(configuration.AllowedOrigins, ShouldContain, "https://publishing.ons.gov.uk")
+		So(configuration.AllowedOrigins, ShouldBeBlank)
 	})
 }

--- a/middleware/origin.go
+++ b/middleware/origin.go
@@ -25,7 +25,7 @@ func SetAllowOriginHeader(allowedOrigins []string) func(h http.Handler) http.Han
 					}
 				}
 
-				if acceptedOrigin == ""{
+				if acceptedOrigin == "" {
 					log.InfoCtx(r.Context(), "request received but origin not allowed, returning 401",
 						log.Data{"origin": origin, "allowed_origins": allowedOrigins})
 					w.WriteHeader(http.StatusUnauthorized)

--- a/middleware/origin.go
+++ b/middleware/origin.go
@@ -11,23 +11,29 @@ func SetAllowOriginHeader(allowedOrigins []string) func(h http.Handler) http.Han
 
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
-			acceptedOrigin := ""
 			origin := r.Header.Get("Origin")
-			for _, v := range allowedOrigins {
-				if v == origin {
-					acceptedOrigin = origin
-					break
+
+			// Only check the origin if it's actually a cross origin request
+			if origin != "" {
+
+				acceptedOrigin := ""
+				for _, v := range allowedOrigins {
+
+					if v == origin {
+						acceptedOrigin = origin
+						break
+					}
 				}
+
+				if acceptedOrigin == ""{
+					log.InfoCtx(r.Context(), "request received but origin not allowed, returning 401",
+						log.Data{"origin": origin, "allowed_origins": allowedOrigins})
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+				w.Header().Set("Access-Control-Allow-Origin", acceptedOrigin)
 			}
 
-			if acceptedOrigin == "" {
-				log.InfoCtx(r.Context(), "request received but origin not allowed, returning 401",
-					log.Data{"origin": origin, "allowed_origins": allowedOrigins})
-				w.WriteHeader(http.StatusUnauthorized)
-				return
-			}
-
-			w.Header().Set("Access-Control-Allow-Origin", acceptedOrigin)
 			h.ServeHTTP(w, r)
 		})
 	}


### PR DESCRIPTION
### What

The cross origin handler was too strict, and was automatically failing all non cross origin requests (as they'll never have an origin to check). Have modified it to apply more selectively.

Also added the other .publishing domains to save us a little work in future.

### How to review

Sanity check

### Who can review

anyone