### PR TITLE
Ensure correct secrets path is used

### DIFF
--- a/dp-api-router.nomad
+++ b/dp-api-router.nomad
@@ -26,7 +26,7 @@ job "dp-api-router" {
       mode     = "delay"
     }
 
-    task "dp-api-router" {
+    task "dp-api-router-web" {
       driver = "docker"
 
       artifact {
@@ -86,7 +86,7 @@ job "dp-api-router" {
       mode     = "delay"
     }
 
-    task "dp-api-router" {
+    task "dp-api-router-publishing" {
       driver = "docker"
 
       artifact {


### PR DESCRIPTION
The secrets have now been split into web and publishing.  The secrets
are determined by the task name.  This change ensures the correct
secrets are loaded.