### PR TITLE
Feature/audit handler send kafka event

### DIFF
--- a/event/producer.go
+++ b/event/producer.go
@@ -25,7 +25,7 @@ func NewAvroProducer(outputChannel chan []byte, marshaller Marshaller) *AvroProd
 	}
 }
 
-// Audit produces a new Audit event. This
+// Audit produces a new Audit event.
 func (producer *AvroProducer) Audit(event *Audit) error {
 	bytes, err := producer.Marshal(event)
 	if err != nil {

--- a/event/producer.go
+++ b/event/producer.go
@@ -25,20 +25,25 @@ func NewAvroProducer(outputChannel chan []byte, marshaller Marshaller) *AvroProd
 	}
 }
 
-// Audit produces a new Audit event.
+// Audit produces a new Audit event. This
 func (producer *AvroProducer) Audit(event *Audit) error {
-	if event == nil {
-		return errors.New("event required but was nil")
-	}
-	return producer.marshalAndSendEvent(event)
-}
-
-//marshalAndSendEvent is a generic function that marshals avro events and sends them to the output channel of the producer
-func (producer *AvroProducer) marshalAndSendEvent(event interface{}) error {
-	bytes, err := producer.marshaller.Marshal(event)
+	bytes, err := producer.Marshal(event)
 	if err != nil {
 		return err
 	}
-	producer.out <- bytes
+	producer.Send(bytes)
 	return nil
+}
+
+// Marshal marshalls an Audit event and returns the corresponding byte array
+func (producer *AvroProducer) Marshal(event *Audit) ([]byte, error) {
+	if event == nil {
+		return nil, errors.New("event required but was nil")
+	}
+	return producer.marshaller.Marshal(event)
+}
+
+// Send sends the byte array to the output channel
+func (producer *AvroProducer) Send(bytes []byte) {
+	producer.out <- bytes
 }

--- a/middleware/audit.go
+++ b/middleware/audit.go
@@ -5,18 +5,37 @@ import (
 	"time"
 
 	"github.com/ONSdigital/dp-api-router/event"
+	"github.com/ONSdigital/dp-api-router/schema"
+	kafka "github.com/ONSdigital/dp-kafka"
 	dphttp "github.com/ONSdigital/dp-net/http"
 	"github.com/ONSdigital/log.go/log"
 )
 
 // AuditHandler is a middleware handler that keeps track of calls that are proxied for auditing purposes.
-func AuditHandler(h http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		auditBeforeProxying(r)
-		rec := &responseRecorder{w, http.StatusOK}
-		h.ServeHTTP(rec, r)
-		auditAfterProxying(r, rec)
-	})
+func AuditHandler(auditKafkaProducer kafka.IProducer) func(h http.Handler) http.Handler {
+	auditProducer := event.NewAvroProducer(auditKafkaProducer.Channels().Output, schema.AuditEvent)
+
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+			// Audit before proxying
+			auditEvent := generateAuditEvent(r)
+			if err := auditProducer.Audit(auditEvent); err != nil {
+				handleAuditError(w, r, auditEvent)
+				return
+			}
+
+			// Proxy the call, recording the status code
+			rec := &responseRecorder{w, http.StatusOK}
+			h.ServeHTTP(rec, r)
+
+			// Audit after proxying
+			auditEvent.StatusCode = int32(rec.status)
+			if err := auditProducer.Audit(auditEvent); err != nil {
+				handleAuditError(w, r, auditEvent)
+			}
+		})
+	}
 }
 
 // responseRecorder implements ResponseWriter and keeps track of the status code
@@ -31,26 +50,16 @@ func (rec *responseRecorder) WriteHeader(code int) {
 	rec.ResponseWriter.WriteHeader(code)
 }
 
-// auditBeforeProxying is called before the HTTP request is proxied to its final destination
-// it will generate an Audit event and send it as a kafka message
-func auditBeforeProxying(req *http.Request) {
-	auditEvent := generateAuditEvent(req)
-	log.Event(req.Context(), "audit before proxying", log.INFO, log.Data{"event": auditEvent})
-}
-
-// auditAfterProxying is called after the HTTP response is received from its final destination.
-// it will generate an Audit event and send it as a kafka message
-func auditAfterProxying(req *http.Request, resp *responseRecorder) {
-	auditEvent := generateAuditEvent(req)
-	auditEvent.StatusCode = int32(resp.status)
-	log.Event(req.Context(), "audit after proxying", log.INFO, log.Data{"event": auditEvent})
+//Now is a time.Now wrapper
+var Now = func() time.Time {
+	return time.Now()
 }
 
 // generateAuditEvent creates an audit event with the values from request and request context, if present.
 func generateAuditEvent(req *http.Request) *event.Audit {
 	ctx := req.Context()
 	auditEvent := &event.Audit{
-		CreatedAt:  event.CreatedAtMillis(time.Now()),
+		CreatedAt:  event.CreatedAtMillis(Now()),
 		Path:       req.URL.Path,
 		Method:     req.Method,
 		QueryParam: req.URL.RawQuery,
@@ -65,4 +74,11 @@ func generateAuditEvent(req *http.Request) *event.Audit {
 		auditEvent.CollectionID = ctx.Value(dphttp.CollectionIDHeaderKey).(string)
 	}
 	return auditEvent
+}
+
+// handleAuditError logs the audit event that failed to be sent and sets the HTTP error response and empty body
+func handleAuditError(w http.ResponseWriter, r *http.Request, auditEvent *event.Audit) {
+	log.Event(r.Context(), "audit event could not be sent", log.ERROR, log.Data{"event": auditEvent})
+	w.Write([]byte{})
+	w.WriteHeader(http.StatusInternalServerError)
 }

--- a/middleware/audit.go
+++ b/middleware/audit.go
@@ -1,20 +1,18 @@
 package middleware
 
 import (
+	"bytes"
+	"io"
 	"net/http"
 	"time"
 
 	"github.com/ONSdigital/dp-api-router/event"
-	"github.com/ONSdigital/dp-api-router/schema"
-	kafka "github.com/ONSdigital/dp-kafka"
 	dphttp "github.com/ONSdigital/dp-net/http"
 	"github.com/ONSdigital/log.go/log"
 )
 
 // AuditHandler is a middleware handler that keeps track of calls that are proxied for auditing purposes.
-func AuditHandler(auditKafkaProducer kafka.IProducer) func(h http.Handler) http.Handler {
-	auditProducer := event.NewAvroProducer(auditKafkaProducer.Channels().Output, schema.AuditEvent)
-
+func AuditHandler(auditProducer *event.AvroProducer) func(h http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
@@ -25,32 +23,49 @@ func AuditHandler(auditKafkaProducer kafka.IProducer) func(h http.Handler) http.
 				return
 			}
 
-			// Proxy the call, recording the status code
-			rec := &responseRecorder{w, http.StatusOK}
+			// Proxy the call with our responseRecorder
+			rec := &responseRecorder{w, http.StatusOK, &bytes.Buffer{}}
 			h.ServeHTTP(rec, r)
 
-			// Audit after proxying
-			auditEvent.StatusCode = int32(rec.status)
-			if err := auditProducer.Audit(auditEvent); err != nil {
+			// Audit after proxying. We need to marshal first, and then send it there is no other error in the process
+			auditEvent.StatusCode = int32(rec.statusCode)
+			eventBytes, err := auditProducer.Marshal(auditEvent)
+			if err != nil {
 				handleAuditError(w, r, auditEvent)
+				return
 			}
+
+			// Copy the intercepted body and header to the original response writer
+			w.WriteHeader(rec.statusCode)
+			if _, err := io.Copy(w, rec.body); err != nil {
+				handleResponseCopyError(w, r, auditEvent)
+				return
+			}
+
+			// Finally send the outbound audit message
+			auditProducer.Send(eventBytes)
 		})
 	}
 }
 
-// responseRecorder implements ResponseWriter and keeps track of the status code
+// responseRecorder implements ResponseWriter and intercepts status code and body
 type responseRecorder struct {
 	http.ResponseWriter
-	status int
+	statusCode int
+	body       *bytes.Buffer
 }
 
-// WriteHeader intercepts the status code and stores it in rec.status
-func (rec *responseRecorder) WriteHeader(code int) {
-	rec.status = code
-	rec.ResponseWriter.WriteHeader(code)
+// WriteHeader intercepts the status code and stores it in rec.statusCode instead of setting it to the wrapped responseWriter
+func (rec *responseRecorder) WriteHeader(status int) {
+	rec.statusCode = status
 }
 
-//Now is a time.Now wrapper
+// Write intercepts the body and stores it in rec.body instead of writing it to the wrapped responseWriter
+func (rec *responseRecorder) Write(b []byte) (int, error) {
+	return rec.body.Write(b)
+}
+
+// Now is a time.Now wrapper
 var Now = func() time.Time {
 	return time.Now()
 }
@@ -79,6 +94,14 @@ func generateAuditEvent(req *http.Request) *event.Audit {
 // handleAuditError logs the audit event that failed to be sent and sets the HTTP error response and empty body
 func handleAuditError(w http.ResponseWriter, r *http.Request, auditEvent *event.Audit) {
 	log.Event(r.Context(), "audit event could not be sent", log.ERROR, log.Data{"event": auditEvent})
-	w.Write([]byte{})
 	w.WriteHeader(http.StatusInternalServerError)
+	w.Write([]byte{})
+}
+
+// handleResponseCopyError logs the error and sets the HTTP error response and empty body
+func handleResponseCopyError(w http.ResponseWriter, r *http.Request, auditEvent *event.Audit) {
+	log.Event(r.Context(), "error copying the intercepted responseWriter into the final responseWriter, after successfully having generated the audit event",
+		log.ERROR, log.Data{"event": auditEvent})
+	w.WriteHeader(http.StatusInternalServerError)
+	w.Write([]byte{})
 }

--- a/middleware/audit_test.go
+++ b/middleware/audit_test.go
@@ -1,75 +1,179 @@
-package middleware
+package middleware_test
 
 import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/ONSdigital/dp-api-router/event"
+	"github.com/ONSdigital/dp-api-router/middleware"
+	"github.com/ONSdigital/dp-api-router/schema"
+	kafkatest "github.com/ONSdigital/dp-kafka/kafkatest"
 	dphttp "github.com/ONSdigital/dp-net/http"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 var (
-	NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-	})
-	testRequestID    = "myRequest"
-	testIdentity     = "myIdentity"
-	testCollectionID = "myCollection"
+	testRequestID          = "myRequest"
+	testIdentity           = "myIdentity"
+	testCollectionID       = "myCollection"
+	testTime               = time.Date(2020, time.April, 26, 7, 5, 52, 123000000, time.UTC)
+	testTimeMillis   int64 = 1587884752123
 )
+
+func testHandler(statusCode int) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(statusCode)
+	})
+}
 
 func TestAuditHandler(t *testing.T) {
 
-	Convey("Given a proxied successful request wrapped by an AuditHandler", t, func() {
-		req, err := http.NewRequest("GET", "/v1/datasets", nil)
+	middleware.Now = func() time.Time {
+		return testTime
+	}
+
+	Convey("Given a proxied successful request wrapped by an AuditHandler", t, func(c C) {
+
+		// prepare request
+		req, err := http.NewRequest(http.MethodGet, "/v1/datasets?q1=v1&q2=v2", nil)
 		So(err, ShouldBeNil)
 		w := httptest.NewRecorder()
-		wrapped := AuditHandler(dummyHandler)
-		wrapped.ServeHTTP(w, req)
 
-		Convey("Then status OK is returned", func() {
-			So(w.Code, ShouldEqual, http.StatusOK)
+		// execute request and wait for audit events
+		auditBefore, auditAfter := serveAndCaptureAudit(c, w, req, testHandler(http.StatusOK), true)
+
+		expectedAuditEvent := event.Audit{
+			CreatedAt:  testTimeMillis,
+			Path:       "/v1/datasets",
+			Method:     http.MethodGet,
+			QueryParam: "q1=v1&q2=v2",
+		}
+
+		Convey("Then status OK is returned", func(c C) {
+			c.So(w.Code, ShouldEqual, http.StatusOK)
 		})
 
-		Convey("And the expected Audit events are sent to kafka before and after the call", func() {
-			// TODO validate that expected event is sent, once implemented
+		Convey("The expected audit event is sent before proxying the call", func() {
+			c.So(auditBefore, ShouldResemble, expectedAuditEvent)
+		})
+
+		Convey("And the expected audit event with OK status code is sent after proxying the call", func() {
+			expectedAuditEvent.StatusCode = int32(http.StatusOK)
+			c.So(auditAfter, ShouldResemble, expectedAuditEvent)
 		})
 	})
 
-	Convey("Given a proxied successful request with context values for requestID, identity and collectionID, wrapped by an AuditHandler", t, func() {
+	Convey("Given a proxied successful request with context values for requestID, identity and collectionID, wrapped by an AuditHandler", t, func(c C) {
+
+		// prepare test
 		req, err := http.NewRequest("GET", "/v1/datasets", nil)
 		So(err, ShouldBeNil)
 		req = req.WithContext(context.WithValue(req.Context(), dphttp.RequestIdKey, testRequestID))
 		req = req.WithContext(context.WithValue(req.Context(), dphttp.CallerIdentityKey, testIdentity))
 		req = req.WithContext(context.WithValue(req.Context(), dphttp.CollectionIDHeaderKey, testCollectionID))
 		w := httptest.NewRecorder()
-		wrapped := AuditHandler(dummyHandler)
-		wrapped.ServeHTTP(w, req)
+
+		// execute request and wait for audit events
+		auditBefore, auditAfter := serveAndCaptureAudit(c, w, req, testHandler(http.StatusOK), true)
+
+		expectedAuditEvent := event.Audit{
+			CreatedAt:    testTimeMillis,
+			RequestID:    testRequestID,
+			Identity:     testIdentity,
+			CollectionID: testCollectionID,
+			Path:         "/v1/datasets",
+			Method:       http.MethodGet,
+			QueryParam:   "",
+		}
 
 		Convey("Then status OK is returned", func() {
 			So(w.Code, ShouldEqual, http.StatusOK)
 		})
 
-		Convey("And the expected Audit events are sent to kafka before and after the call", func() {
-			// TODO validate that expected event is sent, once implemented
+		Convey("The expected audit event is sent before proxying the call", func() {
+			c.So(auditBefore, ShouldResemble, expectedAuditEvent)
+		})
+
+		Convey("And the expected audit event with OK status code is sent after proxying the call", func() {
+			expectedAuditEvent.StatusCode = int32(http.StatusOK)
+			c.So(auditAfter, ShouldResemble, expectedAuditEvent)
 		})
 	})
 
-	Convey("Given a proxied NotFound request wrapped by an AuditHandler", t, func() {
+	Convey("Given a proxied NotFound request wrapped by an AuditHandler", t, func(c C) {
+
+		// prepare test
 		req, err := http.NewRequest("GET", "/v1/datasets", nil)
 		So(err, ShouldBeNil)
 		w := httptest.NewRecorder()
-		wrapped := AuditHandler(NotFoundHandler)
-		wrapped.ServeHTTP(w, req)
+
+		// execute request and wait for audit events
+		auditBefore, auditAfter := serveAndCaptureAudit(c, w, req, testHandler(http.StatusNotFound), true)
+
+		expectedAuditEvent := event.Audit{
+			CreatedAt:  testTimeMillis,
+			Path:       "/v1/datasets",
+			Method:     http.MethodGet,
+			QueryParam: "",
+		}
 
 		Convey("Then status NotFound is returned", func() {
 			So(w.Code, ShouldEqual, http.StatusNotFound)
 		})
 
-		Convey("And the expected Audit events are sent to kafka before and after the call", func() {
-			// TODO validate that expected event is sent, once implemented
+		Convey("The expected audit event is sent before proxying the call", func() {
+			c.So(auditBefore, ShouldResemble, expectedAuditEvent)
+		})
+
+		Convey("And the expected audit event with NotFound status code is sent after proxying the call", func() {
+			expectedAuditEvent.StatusCode = int32(http.StatusNotFound)
+			c.So(auditAfter, ShouldResemble, expectedAuditEvent)
 		})
 	})
+
+	Convey("Given a proxied call with a failing auditing before the call (inbound)", t, func() {
+		// TODO verify 500 and empty body
+		So(true, ShouldBeTrue)
+	})
+
+	Convey("Given a proxied call with a failing auditing after the call (outbound)", t, func() {
+		// TODO verify 500 and empty body
+		So(true, ShouldBeTrue)
+	})
+}
+
+// aux function for testing that serves HTTP, wrapping the provided handler with AuditHandler, and waits for the audit events to be sent
+func serveAndCaptureAudit(c C, w http.ResponseWriter, req *http.Request, innerHandler http.Handler, expectAfter bool) (auditBefore, auditAfter event.Audit) {
+
+	// create testing kafka producer and audit handler wrapping the provided handler
+	p := kafkatest.NewMessageProducer(true)
+	wrapped := middleware.AuditHandler(p)(innerHandler)
+
+	// run HTTP server in a parallel go-routine
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		wrapped.ServeHTTP(w, req)
+	}()
+
+	auditBefore = captureAuditEvents(c, p.Channels().Output)
+	if expectAfter {
+		auditAfter = captureAuditEvents(c, p.Channels().Output)
+	}
+	wg.Wait()
+	return auditBefore, auditAfter
+}
+
+func captureAuditEvents(c C, outChan chan []byte) event.Audit {
+	messageBytes := <-outChan
+	auditEvent := event.Audit{}
+	err := schema.AuditEvent.Unmarshal(messageBytes, &auditEvent)
+	c.So(err, ShouldBeNil)
+	return auditEvent
 }

--- a/service/service.go
+++ b/service/service.go
@@ -6,8 +6,10 @@ import (
 	"net/http"
 
 	"github.com/ONSdigital/dp-api-router/config"
+	"github.com/ONSdigital/dp-api-router/event"
 	"github.com/ONSdigital/dp-api-router/middleware"
 	"github.com/ONSdigital/dp-api-router/proxy"
+	"github.com/ONSdigital/dp-api-router/schema"
 	kafka "github.com/ONSdigital/dp-kafka"
 	"github.com/ONSdigital/go-ns/server"
 	"github.com/ONSdigital/log.go/log"
@@ -102,8 +104,8 @@ func (svc *Service) SetMiddleware(cfg *config.Config) {
 
 	if cfg.EnableAudit {
 		// Audit - send kafka message to track user requests
-		// TODO provide event producer externally, to make it testable
-		svc.Server.Middleware[MidAudit] = middleware.AuditHandler(svc.KafkaAuditProducer)
+		auditProducer := event.NewAvroProducer(svc.KafkaAuditProducer.Channels().Output, schema.AuditEvent)
+		svc.Server.Middleware[MidAudit] = middleware.AuditHandler(auditProducer)
 		svc.Server.MiddlewareOrder = append(svc.Server.MiddlewareOrder, MidAudit)
 	}
 	svc.Server.MiddlewareOrder = append(svc.Server.MiddlewareOrder, MidCors)

--- a/service/service.go
+++ b/service/service.go
@@ -102,7 +102,8 @@ func (svc *Service) SetMiddleware(cfg *config.Config) {
 
 	if cfg.EnableAudit {
 		// Audit - send kafka message to track user requests
-		svc.Server.Middleware[MidAudit] = middleware.AuditHandler
+		// TODO provide event producer externally, to make it testable
+		svc.Server.Middleware[MidAudit] = middleware.AuditHandler(svc.KafkaAuditProducer)
 		svc.Server.MiddlewareOrder = append(svc.Server.MiddlewareOrder, MidAudit)
 	}
 	svc.Server.MiddlewareOrder = append(svc.Server.MiddlewareOrder, MidCors)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -13,6 +13,7 @@ import (
 	proxyMock "github.com/ONSdigital/dp-api-router/proxy/mock"
 	"github.com/ONSdigital/dp-api-router/service"
 	"github.com/ONSdigital/dp-api-router/service/mock"
+	"github.com/ONSdigital/dp-kafka/kafkatest"
 	"github.com/ONSdigital/go-ns/server"
 	"github.com/justinas/alice"
 	. "github.com/smartystreets/goconvey/convey"
@@ -354,6 +355,7 @@ func TestMiddleware(t *testing.T) {
 		}
 
 		Convey("Then if private endpoints and audit are enabled, audit is added before cors middleware", func() {
+			svc.KafkaAuditProducer = kafkatest.NewMessageProducer(true)
 			cfg := &config.Config{
 				EnablePrivateEndpoints: true,
 				EnableAudit:            true,
@@ -363,6 +365,7 @@ func TestMiddleware(t *testing.T) {
 		})
 
 		Convey("Then if private endpoints are disabled and audit is enabled, audit is added before cors middleware", func() {
+			svc.KafkaAuditProducer = kafkatest.NewMessageProducer(true)
 			cfg := &config.Config{
 				EnablePrivateEndpoints: false,
 				EnableAudit:            true,


### PR DESCRIPTION
### What

Send Kafka message on audit events:
- Before: with no status code
- After: with status code
- If any error happens when trying to send an audit event: Set 500 Error and empty body

Ignore `/health` and `/healthcheck` paths for auditing purposes.

### How to review

- Verify that the code changes make sense
- Unit tests should pass
- Optionally, you can run this service with `make debug`, run the audit kafka consumer from https://github.com/ONSdigital/dp-data-tools/pull/10 and validate that the kafka audit messages are correctly produced (except for `/health`), and consumed.

### Who can review
Anyone

