### PR TITLE
Ignore clickEventLog in audit middleware

### DIFF
--- a/middleware/audit.go
+++ b/middleware/audit.go
@@ -19,6 +19,7 @@ import (
 // paths that will skip auditing (note)
 var pathsToIgnore = []string{
 	"/ping",
+	"/clickEventLog",
 }
 
 // paths that will skip retrieveIdentity, and will be audited without identity

--- a/middleware/audit_test.go
+++ b/middleware/audit_test.go
@@ -448,7 +448,7 @@ func TestAuditIgnoreSkip(t *testing.T) {
 			p, a := createValidAuditHandler()
 			auditHandler := a(testHandler(http.StatusForbidden, testBody))
 
-			// execute request and don't wait for audit events
+			// execute request and wait for 2 audit events
 			auditEvents := serveAndCaptureAudit(c, w, req, auditHandler, p.Channels().Output, 2)
 
 			Convey("Then status Forbidden and expected body is returned", func(c C) {


### PR DESCRIPTION
### What

- Added `clickEventLog ` to audit ignored paths list
- fixed comment in test

### How to review

- Make sure change make sense (according to https://github.com/ONSdigital/florence/pull/450 PR comment)
- Unit tests should pass

### Who can review

Anyone