### PR TITLE
Origin middleware allows any origin if the '*' wildchar is provided

### DIFF
--- a/middleware/origin.go
+++ b/middleware/origin.go
@@ -20,7 +20,7 @@ func SetAllowOriginHeader(allowedOrigins []string) func(h http.Handler) http.Han
 				acceptedOrigin := ""
 				for _, v := range allowedOrigins {
 
-					if v == origin {
+					if v == origin || v == "*" {
 						acceptedOrigin = origin
 						break
 					}

--- a/middleware/origin_test.go
+++ b/middleware/origin_test.go
@@ -4,8 +4,9 @@ import (
 	"net/http"
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
 	"net/http/httptest"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 const (
@@ -39,7 +40,21 @@ func TestOriginHandler(t *testing.T) {
 		wrapped.ServeHTTP(w, req)
 		So(w.Code, ShouldEqual, 200)
 		So(w.Header().Get("Access-Control-Allow-Origin"), ShouldEqual, whiteListedOrigin1)
+	})
 
+	Convey("origin handler should serve the request where the origin is allowed because of asterisk wildchar", t, func() {
+		req, err := http.NewRequest("GET", "/", nil)
+		So(err, ShouldBeNil)
+
+		req.Header.Set("Origin", "anything")
+		w := httptest.NewRecorder()
+
+		handler := SetAllowOriginHeader([]string{"*"})
+		wrapped := handler(dummyHandler)
+
+		wrapped.ServeHTTP(w, req)
+		So(w.Code, ShouldEqual, 200)
+		So(w.Header().Get("Access-Control-Allow-Origin"), ShouldEqual, "anything")
 	})
 
 	Convey("origin handler should return 401 unauthorised where origin is not allowed", t, func() {


### PR DESCRIPTION
### What

Origin middleware will allow any origin if '*' is provided in config. This is to support configs that were observed in dp-configs, although they are not used at the moment (in web mode this middleware is disabled).

### How to review

- Make sure code changes make sense
- Unit tests should pass

### Who can review

Anyone