### PR TITLE
Handle nil resource type in interceptor reflect

### DIFF
--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -88,7 +88,12 @@ func (t *Transport) update(b []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	switch reflect.TypeOf(resource).Kind() {
+	resourceType := reflect.TypeOf(resource)
+	if resourceType == nil {
+		return nil, errors.New("nil resource type")
+	}
+
+	switch resourceType.Kind() {
 	case reflect.Map:
 		// Assert type onto document
 		return t.updateMap(resource.(map[string]interface{}))


### PR DESCRIPTION
### What

In some calls, a nil type is provided to the RoundTripper. This was not correctly handled before and it was generating a panic. Then the caller wouldn't receive a valid response for the call that was being routed.

I added a nil pointer check, and if the type is nil we return an error, which is a valid scenario (it just means that the links will not be updated in the request body).

Example of a call that was failing: 
```
curl --location --request GET 'http://<filterDatasetController>/filters/39835bee-b4eb-4aa5-a5a3-3f8e3e4f220a/dimensions' \
--header 'X-Florence-Token:<florenceToken>'
```

### How to review

- Make sure code changes make sense
- Unit tests should pass

### Who can review

Anyone