### PR TITLE
Create Zebedee client and register its checker always

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -43,9 +43,11 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 		log.Event(ctx, "beta route restriction is active, /v1 api requests will only be permitted against beta domains", log.INFO)
 	}
 
-	// Get Zebedee client and Kafka Audit Producer (only if audit is enabled)
+	// Create Zebedee client
+	svc.ZebedeeClient = health.NewClient("Zebedee", cfg.ZebedeeURL)
+
+	// Get Kafka Audit Producer (only if audit is enabled)
 	if cfg.EnableAudit {
-		svc.ZebedeeClient = health.NewClient("Zebedee", cfg.ZebedeeURL)
 		svc.KafkaAuditProducer, err = serviceList.GetKafkaAuditProducer(ctx, cfg)
 		if err != nil {
 			log.Event(ctx, "could not instantiate kafka audit producer", log.FATAL, log.Error(err))
@@ -222,15 +224,15 @@ func (svc *Service) Close(ctx context.Context) error {
 func (svc *Service) registerCheckers(ctx context.Context) (err error) {
 	hasErrors := false
 
+	if err = svc.HealthCheck.AddCheck("Zebedee", svc.ZebedeeClient.Checker); err != nil {
+		hasErrors = true
+		log.Event(ctx, "failed to add zebedee checker", log.ERROR, log.Error(err))
+	}
+
 	if svc.Config.EnableAudit {
 		if err = svc.HealthCheck.AddCheck("Kafka Audit Producer", svc.KafkaAuditProducer.Checker); err != nil {
 			hasErrors = true
 			log.Event(ctx, "failed to add kafka audit producer checker", log.ERROR, log.Error(err))
-		}
-
-		if err = svc.HealthCheck.AddCheck("Zebedee", svc.ZebedeeClient.Checker); err != nil {
-			hasErrors = true
-			log.Event(ctx, "failed to add zebedee checker", log.ERROR, log.Error(err))
 		}
 	}
 


### PR DESCRIPTION
### What

Create Zebedee client always (regardless of the auditing flag).
That is because we need to proxy Zebedee calls even if auditing is disabled.

### How to review

- Make sure code changes make sense
- Unit tests should pass

### Who can review

Anyone