### PR TITLE
Allow internal traffic through the beta domain restriction 

### DIFF
--- a/middleware/beta.go
+++ b/middleware/beta.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"net"
 	"net/http"
 	"strings"
 
@@ -12,7 +13,7 @@ func BetaApiHandler(enableBetaRestriction bool, h http.Handler) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
-		if enableBetaRestriction && !strings.HasPrefix(r.Host, "api.beta") {
+		if enableBetaRestriction && !isInternalTraffic(r) && !isBetaDomain(r) {
 
 			log.Event(r.Context(), "beta endpoint requested via a non beta domain, returning 404", log.WARN,
 				log.Data{"url": r.URL.String()})
@@ -23,4 +24,24 @@ func BetaApiHandler(enableBetaRestriction bool, h http.Handler) http.Handler {
 
 		h.ServeHTTP(w, r)
 	})
+}
+
+func isBetaDomain(r *http.Request) bool {
+	return strings.HasPrefix(r.Host, "api.beta")
+}
+
+func isInternalTraffic(r *http.Request) bool {
+
+	// exclude the port from the potential IP address
+	host, _, err := net.SplitHostPort(r.Host)
+	if err != nil {
+		// if we fail to split from the port, just use the original host value
+		host = r.Host
+	}
+
+	return isValidIP(host)
+}
+
+func isValidIP(host string) bool {
+	return net.ParseIP(host) != nil
 }

--- a/middleware/beta.go
+++ b/middleware/beta.go
@@ -39,7 +39,7 @@ func isInternalTraffic(r *http.Request) bool {
 		host = r.Host
 	}
 
-	return isValidIP(host)
+	return isValidIP(host) || host == "localhost"
 }
 
 func isValidIP(host string) bool {

--- a/middleware/beta_test.go
+++ b/middleware/beta_test.go
@@ -86,6 +86,34 @@ func TestBetaHandler(t *testing.T) {
 			So(w.Code, ShouldEqual, 200)
 
 		})
+
+		Convey("a request to localhost should return 200 status", func() {
+			req, err := http.NewRequest("GET", "/", nil)
+			So(err, ShouldBeNil)
+
+			req.Host = "localhost"
+
+			w := httptest.NewRecorder()
+			wrapped := BetaApiHandler(true, dummyHandler)
+
+			wrapped.ServeHTTP(w, req)
+			So(w.Code, ShouldEqual, 200)
+
+		})
+
+		Convey("a request to localhost with a port should return 200 status", func() {
+			req, err := http.NewRequest("GET", "/", nil)
+			So(err, ShouldBeNil)
+
+			req.Host = "localhost:20300"
+
+			w := httptest.NewRecorder()
+			wrapped := BetaApiHandler(true, dummyHandler)
+
+			wrapped.ServeHTTP(w, req)
+			So(w.Code, ShouldEqual, 200)
+
+		})
 	})
 
 	Convey("where beta restrictions are not enabled", t, func() {

--- a/middleware/beta_test.go
+++ b/middleware/beta_test.go
@@ -44,6 +44,48 @@ func TestBetaHandler(t *testing.T) {
 			So(w.Code, ShouldEqual, 404)
 
 		})
+
+		Convey("a request to an internal IP and port should return 200 status", func() {
+			req, err := http.NewRequest("GET", "/", nil)
+			So(err, ShouldBeNil)
+
+			req.Host = "10.201.4.85:80"
+
+			w := httptest.NewRecorder()
+			wrapped := BetaApiHandler(true, dummyHandler)
+
+			wrapped.ServeHTTP(w, req)
+			So(w.Code, ShouldEqual, 200)
+
+		})
+
+		Convey("a request to a non beta host and port should return 404 status", func() {
+			req, err := http.NewRequest("GET", "/", nil)
+			So(err, ShouldBeNil)
+
+			req.Host = "somehost:20100"
+
+			w := httptest.NewRecorder()
+			wrapped := BetaApiHandler(true, dummyHandler)
+
+			wrapped.ServeHTTP(w, req)
+			So(w.Code, ShouldEqual, 404)
+
+		})
+
+		Convey("a request to an internal IP should return 200 status", func() {
+			req, err := http.NewRequest("GET", "/", nil)
+			So(err, ShouldBeNil)
+
+			req.Host = "10.201.4.85"
+
+			w := httptest.NewRecorder()
+			wrapped := BetaApiHandler(true, dummyHandler)
+
+			wrapped.ServeHTTP(w, req)
+			So(w.Code, ShouldEqual, 200)
+
+		})
 	})
 
 	Convey("where beta restrictions are not enabled", t, func() {

--- a/service/service.go
+++ b/service/service.go
@@ -154,7 +154,7 @@ func CreateRouter(ctx context.Context, cfg *config.Config, hc HealthChecker) *mu
 	addLegacyHandler(router, poc, "/timeseries")
 	addLegacyHandler(router, poc, "/search")
 
-	zebedee := proxy.NewAPIProxy(cfg.ZebedeeURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	zebedee := proxy.NewAPIProxy(cfg.ZebedeeURL, cfg.Version, cfg.EnvironmentHost, "", false)
 	addLegacyHandler(router, zebedee, "/{uri:.*}")
 
 	return router


### PR DESCRIPTION
### What

When the beta domain restriction is enabled, it blocks all traffic that is not for the `api.beta` domain. We need to allow all internal traffic through this restriction now that all internal API requests go through the API router.

- Allow internal traffic through the beta domain restriction 
- Do not apply the beta domain restriction to zebedee (legacy) endpoints

### How to review
- Review code / tests

### Who can review
Anyone
