### PR TITLE
Fix CORS issue with public API access

### DIFF
--- a/middleware/origin.go
+++ b/middleware/origin.go
@@ -8,31 +8,41 @@ import (
 
 // SetAllowOriginHeader sets the 'Access-Control-Allow-Origin' field for origin domains we allow. Otherwise returning a 401.
 func SetAllowOriginHeader(allowedOrigins []string) func(h http.Handler) http.Handler {
-	return func(h http.Handler) http.Handler {
+	acceptAllOrigins := false
+	for _, v := range allowedOrigins {
+		if v == "*" {
+			acceptAllOrigins = true
+			break
+		}
+	}
 
+	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
-			origin := r.Header.Get("Origin")
+			if acceptAllOrigins {
+				w.Header().Set("Access-Control-Allow-Origin", "*")
+			} else {
+				origin := r.Header.Get("Origin")
 
-			// Only check the origin if it's actually a cross origin request
-			if origin != "" {
+				// Only check the origin if it's actually a cross origin request
+				if origin != "" {
+					acceptedOrigin := ""
+					for _, v := range allowedOrigins {
 
-				acceptedOrigin := ""
-				for _, v := range allowedOrigins {
-
-					if v == origin || v == "*" {
-						acceptedOrigin = origin
-						break
+						if v == origin || v == "*" {
+							acceptedOrigin = origin
+							break
+						}
 					}
-				}
 
-				if acceptedOrigin == "" {
-					log.Event(r.Context(), "request received but origin not allowed, returning 401", log.WARN,
-						log.Data{"origin": origin, "allowed_origins": allowedOrigins})
-					w.WriteHeader(http.StatusUnauthorized)
-					return
+					if acceptedOrigin == "" {
+						log.Event(r.Context(), "request received but origin not allowed, returning 401", log.WARN,
+							log.Data{"origin": origin, "allowed_origins": allowedOrigins})
+						w.WriteHeader(http.StatusUnauthorized)
+						return
+					}
+					w.Header().Set("Access-Control-Allow-Origin", acceptedOrigin)
 				}
-				w.Header().Set("Access-Control-Allow-Origin", acceptedOrigin)
 			}
 
 			h.ServeHTTP(w, r)

--- a/middleware/origin_test.go
+++ b/middleware/origin_test.go
@@ -54,7 +54,7 @@ func TestOriginHandler(t *testing.T) {
 
 		wrapped.ServeHTTP(w, req)
 		So(w.Code, ShouldEqual, 200)
-		So(w.Header().Get("Access-Control-Allow-Origin"), ShouldEqual, "anything")
+		So(w.Header().Get("Access-Control-Allow-Origin"), ShouldEqual, "*")
 	})
 
 	Convey("origin handler should return 401 unauthorised where origin is not allowed", t, func() {

--- a/service/service.go
+++ b/service/service.go
@@ -107,9 +107,10 @@ func (svc *Service) CreateMiddleware(cfg *config.Config) alice.Chain {
 		// CORS - only allow specified origins in publishing
 		m = m.Append(middleware.SetAllowOriginHeader(cfg.AllowedOrigins))
 	} else {
-		// CORS - only allow certain methods in web
+		// CORS - allow all origin domains, but only allow certain methods in web
 		methodsOk := handlers.AllowedMethods([]string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete})
 		m = m.Append(handlers.CORS(methodsOk))
+		m = m.Append(middleware.SetAllowOriginHeader([]string{"*"}))
 	}
 
 	return m


### PR DESCRIPTION
### What

Public API requests are currently being blocked from other domains due
to our CORS headers. This fix ensures that in public mode the CORS
allowed origin will always be set to a wildcard, meaning that all public
API requests will be allowed.

### Who can review

Anyone but me.
