### PR TITLE
Feature/skip identity improvement

### DIFF
--- a/middleware/audit.go
+++ b/middleware/audit.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"bytes"
 	"context"
+i	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -28,10 +29,13 @@ var pathsToIgnore = []string{
 var pathsSkipIdentity = []string{
 	"/login",
 	"/password",
-	"/v1/hierarchies",
+	"/hierarchies",
 }
 
-func shallSkipIdentity(path string) bool {
+func ShallSkipIdentity(versionPrefix, path string) bool {
+	// TODO need to revisit this if we start supporting multiple versions of the APIs.
+	path = strings.TrimPrefix(path, fmt.Sprintf("/%s", versionPrefix))
+
 	for _, pathSkipIdentity := range pathsSkipIdentity {
 		if strings.HasPrefix(path, pathSkipIdentity) {
 			return true
@@ -52,7 +56,7 @@ func shallIgnore(path string) bool {
 // AuditHandler is a middleware handler that keeps track of calls for auditing purposes,
 // before and after proxying calling the downstream service.
 // It obtains the user and caller information by calling Zebedee GET /identity
-func AuditHandler(auditProducer *event.AvroProducer, cli dphttp.Clienter, zebedeeURL string) func(h http.Handler) http.Handler {
+func AuditHandler(auditProducer *event.AvroProducer, cli dphttp.Clienter, zebedeeURL, versionPrefix string) func(h http.Handler) http.Handler {
 
 	// create Identity client that will be used by middleware to check callers identity
 	idClient := clientsidentity.NewAPIClient(cli, zebedeeURL)
@@ -69,7 +73,7 @@ func AuditHandler(auditProducer *event.AvroProducer, cli dphttp.Clienter, zebede
 			// Inbound audit event (before proxying).
 			auditEvent := generateAuditEvent(r)
 
-			if !shallSkipIdentity(r.URL.Path) {
+			if !ShallSkipIdentity(versionPrefix, r.URL.Path) {
 
 				// Retrieve Identity from Zebedee, which is stored in context.
 				// if it fails, try to audit with the statusCode before returning

--- a/middleware/audit.go
+++ b/middleware/audit.go
@@ -3,7 +3,7 @@ package middleware
 import (
 	"bytes"
 	"context"
-i	"fmt"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"

--- a/middleware/audit_test.go
+++ b/middleware/audit_test.go
@@ -474,7 +474,6 @@ func TestShallSkipIdentity(t *testing.T) {
 
 	for _, p := range skipIdentityPaths {
 		versionedPath := "/v1" + p
-
 		Convey(fmt.Sprintf("Should skip identity check for versioned %s requests", versionedPath), t, func() {
 			So(middleware.ShallSkipIdentity("v1", versionedPath), ShouldBeTrue)
 		})

--- a/service/service.go
+++ b/service/service.go
@@ -100,7 +100,7 @@ func (svc *Service) CreateMiddleware(cfg *config.Config) alice.Chain {
 	// Audit - send kafka message to track user requests
 	if cfg.EnableAudit {
 		auditProducer := event.NewAvroProducer(svc.KafkaAuditProducer.Channels().Output, schema.AuditEvent)
-		m = m.Append(middleware.AuditHandler(auditProducer, svc.ZebedeeClient.Client, cfg.ZebedeeURL))
+		m = m.Append(middleware.AuditHandler(auditProducer, svc.ZebedeeClient.Client, cfg.ZebedeeURL, cfg.Version))
 	}
 
 	if cfg.EnablePrivateEndpoints {


### PR DESCRIPTION
Improvement to handling versioned URLs in the skip identity whitelist. Audit handler now removes the version prefix (based on the app config) if it exists and checks if the url is in the identity check white list. Previously this was hardcoded into the URL values.

Updated code + tests.
