### PR TITLE
Release/1.11.0

### DIFF
--- a/middleware/audit.go
+++ b/middleware/audit.go
@@ -28,7 +28,7 @@ var pathsToIgnore = []string{
 var pathsSkipIdentity = []string{
 	"/login",
 	"/password",
-	"/hierarchies",
+	"/v1/hierarchies",
 }
 
 func shallSkipIdentity(path string) bool {

--- a/middleware/audit.go
+++ b/middleware/audit.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/ONSdigital/dp-api-clients-go/headers"
@@ -20,17 +21,19 @@ import (
 var pathsToIgnore = []string{
 	"/ping",
 	"/clickEventLog",
+	"/health",
 }
 
 // paths that will skip retrieveIdentity, and will be audited without identity
 var pathsSkipIdentity = []string{
 	"/login",
 	"/password",
+	"/hierarchies",
 }
 
 func shallSkipIdentity(path string) bool {
 	for _, pathSkipIdentity := range pathsSkipIdentity {
-		if path == pathSkipIdentity {
+		if strings.HasPrefix(path, pathSkipIdentity) {
 			return true
 		}
 	}

--- a/middleware/audit_test.go
+++ b/middleware/audit_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -25,6 +26,7 @@ import (
 )
 
 var (
+	testVersionPrefix            = "v1"
 	testZebedeeURL               = "myZebedeeURL"
 	testRequestID                = "myRequest"
 	testIdentity                 = "myIdentity"
@@ -59,7 +61,7 @@ func createValidAuditHandler() (kafka.IProducer, func(h http.Handler) http.Handl
 	cliMock := createHTTPClientMock(http.StatusOK, testIdentityResponse)
 	p := kafkatest.NewMessageProducer(true)
 	auditProducer := event.NewAvroProducer(p.Channels().Output, schema.AuditEvent)
-	return p, middleware.AuditHandler(auditProducer, cliMock, testZebedeeURL)
+	return p, middleware.AuditHandler(auditProducer, cliMock, testZebedeeURL, testVersionPrefix)
 }
 
 // utility function to create a producer and an audit handler that fails to marshal and send events
@@ -72,7 +74,7 @@ func createFailingAuditHandler() (kafka.IProducer, func(h http.Handler) http.Han
 	}
 	p := kafkatest.NewMessageProducer(true)
 	auditProducer := event.NewAvroProducer(p.Channels().Output, failingMarshaller)
-	return p, middleware.AuditHandler(auditProducer, cliMock, testZebedeeURL)
+	return p, middleware.AuditHandler(auditProducer, cliMock, testZebedeeURL, testVersionPrefix)
 }
 
 // utility function to generate Clienter mocks
@@ -394,7 +396,7 @@ func TestAuditHandler(t *testing.T) {
 			}
 			p := kafkatest.NewMessageProducer(true)
 			a := event.NewAvroProducer(p.Channels().Output, failingMarshaller)
-			auditHandler := middleware.AuditHandler(a, cliMock, testZebedeeURL)(testHandler(http.StatusForbidden, testBody))
+			auditHandler := middleware.AuditHandler(a, cliMock, testZebedeeURL, testVersionPrefix)(testHandler(http.StatusForbidden, testBody))
 
 			// execute request and expect only 1 audit event
 			auditEvents := serveAndCaptureAudit(c, w, req, auditHandler, p.Channels().Output, 1)
@@ -465,6 +467,21 @@ func TestAuditIgnoreSkip(t *testing.T) {
 
 		})
 	})
+}
+
+func TestShallSkipIdentity(t *testing.T) {
+	skipIdentityPaths := []string{"/password", "/login", "/hierarchies"}
+
+	for _, p := range skipIdentityPaths {
+		versionedPath := "/v1" + p
+		Convey(fmt.Sprintf("Should skip identity check for versioned %s requests", versionedPath), t, func() {
+			So(middleware.ShallSkipIdentity("v1", versionedPath), ShouldBeTrue)
+		})
+
+		Convey(fmt.Sprintf("Should skip identity check for non versioned %s requests", p), t, func() {
+			So(middleware.ShallSkipIdentity("v1", p), ShouldBeTrue)
+		})
+	}
 }
 
 // aux function for testing that serves HTTP, wrapping the provided handler with AuditHandler,

--- a/service/service.go
+++ b/service/service.go
@@ -100,7 +100,7 @@ func (svc *Service) CreateMiddleware(cfg *config.Config) alice.Chain {
 	// Audit - send kafka message to track user requests
 	if cfg.EnableAudit {
 		auditProducer := event.NewAvroProducer(svc.KafkaAuditProducer.Channels().Output, schema.AuditEvent)
-		m = m.Append(middleware.AuditHandler(auditProducer, svc.ZebedeeClient.Client, cfg.ZebedeeURL))
+		m = m.Append(middleware.AuditHandler(auditProducer, svc.ZebedeeClient.Client, cfg.ZebedeeURL, cfg.Version))
 	}
 
 	if cfg.EnablePrivateEndpoints {


### PR DESCRIPTION
### Release 1.11.0

Updated skip identity check to strip the version prefix if it exists from the URI. The version prefix is defined in the config and no longer requires a hardcoded value to be specified in the code.
