### PR TITLE
Fix links interceptor throwing json error on empty response

### DIFF
--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -60,6 +60,10 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 		return nil, err
 	}
 
+	if len(b) == 0 {
+		return resp, nil
+	}
+
 	updatedB, err := t.update(b)
 	if err != nil {
 		log.Event(context.Background(), "could not update response body with correct links", log.ERROR, log.Error(err))

--- a/interceptor/interceptor_test.go
+++ b/interceptor/interceptor_test.go
@@ -26,6 +26,21 @@ func (t dummyRT) RoundTrip(req *http.Request) (resp *http.Response, err error) {
 var _ http.RoundTripper = dummyRT{}
 
 func TestUnitInterceptor(t *testing.T) {
+
+	Convey("test interceptor doesn't throw an error for an empty response", t, func() {
+		testJSON := ``
+		transp := dummyRT{testJSON}
+
+		t := NewRoundTripper(testDomain, "", transp)
+
+		resp, err := t.RoundTrip(nil)
+		So(err, ShouldBeNil)
+
+		b, _ := ioutil.ReadAll(resp.Body)
+
+		So(len(b), ShouldEqual, 0)
+	})
+
 	Convey("test interceptor correctly updates a href in links subdoc", t, func() {
 		testJSON := `{"links":{"self":{"href":"/datasets/12345"}}}`
 		transp := dummyRT{testJSON}


### PR DESCRIPTION
### What

When no json was being returned, for instance on some 404s, failing to unmarshal the empty string was causing noisy errors. If the body has no length, theres nothing to intercept/the function should return

### How to review

Make sure tests pass and api router still behaves as normal
Make sure empty responses no longer error

### Who can review

Anyone