### PR TITLE
Ensure that a closed response body is not returned for empty responses

### DIFF
--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -61,6 +61,7 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 	}
 
 	if len(b) == 0 {
+		resp.Body = ioutil.NopCloser(bytes.NewReader([]byte{}))
 		return resp, nil
 	}
 


### PR DESCRIPTION
### What
Ensure that a closed response body is not returned for empty responses
-The original response body is closed already, so returning it can cause upstream code to fail if it attempts to read the body. Instead return a new empty reader that will not error when closed.

### How to review
Sanity check (I could not replicate locally)

### Who can review
Anyone
