### PR TITLE
add additional new route to point to dimension-search-api

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -141,6 +141,7 @@ func CreateRouter(ctx context.Context, cfg *config.Config, hc HealthChecker) *mu
 	addVersionHandler(router, filter, "/filter-outputs")
 	addVersionHandler(router, hierarchy, "/hierarchies")
 	addVersionHandler(router, search, "/search")
+	addVersionHandler(router, search, "/dimension-search")
 	addVersionHandler(router, image, "/images")
 
 	// Private APIs
@@ -166,6 +167,7 @@ func CreateRouter(ctx context.Context, cfg *config.Config, hc HealthChecker) *mu
 	addLegacyHandler(router, poc, "/dataset")
 	addLegacyHandler(router, poc, "/timeseries")
 	addLegacyHandler(router, poc, "/search")
+	addLegacyHandler(router, poc, "/dimension-search")
 
 	zebedee := proxy.NewAPIProxy(cfg.ZebedeeURL, cfg.Version, cfg.EnvironmentHost, "", false)
 	addLegacyHandler(router, zebedee, "/{uri:.*}")


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
https://trello.com/c/RGbqzfZK/4893-make-dp-search-query-available-through-api-router-1
- Add new route /dimension-search to point to `dp-dimension-search-api` (note that `/search` is also pointing to the service which is okay for now). This will be changed in the future. 

### How to review
**Describe the steps required to test the changes.**
- Check if the code changes make sense

### Who can review
**Describe who worked on the changes, so that other people can review.**
Anyone - Justin made the changes