### PR TITLE
Release/1.14.0

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	RecipeAPIURL               string        `envconfig:"RECIPE_API_URL"`
 	ImportAPIURL               string        `envconfig:"IMPORT_API_URL"`
 	SearchAPIURL               string        `envconfig:"SEARCH_API_URL"`
+	DimensionSearchAPIURL      string        `envconfig:"DIMENSION_SEARCH_API_URL"`
 	ImageAPIURL                string        `envconfig:"IMAGE_API_URL"`
 	UploadServiceAPIURL        string        `envconfig:"UPLOAD_SERVICE_API_URL"`
 	ContextURL                 string        `envconfig:"CONTEXT_URL"`
@@ -66,6 +67,7 @@ func Get() (*Config, error) {
 			RecipeAPIURL:               "http://localhost:22300",
 			ImportAPIURL:               "http://localhost:21800",
 			SearchAPIURL:               "http://localhost:23100",
+			DimensionSearchAPIURL:      "http://localhost:23100",
 			ImageAPIURL:                "http://localhost:24700",
 			UploadServiceAPIURL:        "http://localhost:25100",
 			APIPocURL:                  "http://localhost:3000",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -30,6 +30,7 @@ func TestGetRetrunsDefaultValues(t *testing.T) {
 			ImageAPIURL:                "http://localhost:24700",
 			UploadServiceAPIURL:        "http://localhost:25100",
 			SearchAPIURL:               "http://localhost:23100",
+			DimensionSearchAPIURL:      "http://localhost:23100",
 			APIPocURL:                  "http://localhost:3000",
 			ContextURL:                 "",
 			EnvironmentHost:            "http://localhost:23200",

--- a/service/service.go
+++ b/service/service.go
@@ -140,6 +140,7 @@ func CreateRouter(ctx context.Context, cfg *config.Config, hc HealthChecker) *mu
 	filter := proxy.NewAPIProxy(cfg.FilterAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	hierarchy := proxy.NewAPIProxy(cfg.HierarchyAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	search := proxy.NewAPIProxy(cfg.SearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	dimensionSearch := proxy.NewAPIProxy(cfg.DimensionSearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	image := proxy.NewAPIProxy(cfg.ImageAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	addVersionHandler(router, codeList, "/code-lists")
 	addVersionHandler(router, dataset, "/datasets")
@@ -147,7 +148,7 @@ func CreateRouter(ctx context.Context, cfg *config.Config, hc HealthChecker) *mu
 	addVersionHandler(router, filter, "/filter-outputs")
 	addVersionHandler(router, hierarchy, "/hierarchies")
 	addVersionHandler(router, search, "/search")
-	addVersionHandler(router, search, "/dimension-search")
+	addVersionHandler(router, dimensionSearch, "/dimension-search")
 	addVersionHandler(router, image, "/images")
 
 	// Private APIs
@@ -173,7 +174,6 @@ func CreateRouter(ctx context.Context, cfg *config.Config, hc HealthChecker) *mu
 	addLegacyHandler(router, poc, "/dataset")
 	addLegacyHandler(router, poc, "/timeseries")
 	addLegacyHandler(router, poc, "/search")
-	addLegacyHandler(router, poc, "/dimension-search")
 
 	zebedee := proxy.NewAPIProxy(cfg.ZebedeeURL, cfg.Version, cfg.EnvironmentHost, "", false)
 	router.NotFoundHandler = http.HandlerFunc(zebedee.VersionHandle)


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
Add new config `DimensionSearchAPIURL`
Add `/dimension-search` with reference to the new config
Add tests for the particular endpoint as well

Please note that `SearchAPIURL` and `DimensionSearchAPIURL` have the same values. The `SearchAPIURL` value will be changed in the future but the duplication of these values are meant to be there

### How to review
**Describe the steps required to test the changes.**
Check if the new config has been added and used correctly
Check if the new endpoint has been added correctly with comparison to how previous endpoints were added
Check if the tests pass

### Who can review
**Describe who worked on the changes, so that other people can review.**
Anyone - Justin made the changes
BASED ON PR https://github.com/ONSdigital/dp-api-router/pull/93