### PR TITLE
Do not rewrite URL's that don't need it

### DIFF
--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/ONSdigital/log.go/log"
 )
@@ -259,6 +260,12 @@ func updateArray(docArray []interface{}, domain string) ([]interface{}, error) {
 }
 
 func getLink(field, domain string) (string, error) {
+
+	// if the URL is already correct, return it
+	if strings.HasPrefix(field, domain) {
+		return field, nil
+	}
+
 	uri, err := url.Parse(field)
 	if err != nil {
 		return "", err

--- a/interceptor/interceptor_test.go
+++ b/interceptor/interceptor_test.go
@@ -41,6 +41,20 @@ func TestUnitInterceptor(t *testing.T) {
 		So(len(b), ShouldEqual, 0)
 	})
 
+	Convey("test interceptor doesn't change an already correct link", t, func() {
+		testJSON := `{"links":{"self":{"href":"https://api.beta.ons.gov.uk/v1/datasets/12345"}}}`
+		transp := dummyRT{testJSON}
+
+		t := NewRoundTripper(testDomain, "", transp)
+
+		resp, err := t.RoundTrip(nil)
+		So(err, ShouldBeNil)
+
+		b, _ := ioutil.ReadAll(resp.Body)
+
+		So(string(b), ShouldEqual, `{"links":{"self":{"href":"https://api.beta.ons.gov.uk/v1/datasets/12345"}}}`+"\n")
+	})
+
 	Convey("test interceptor correctly updates a href in links subdoc", t, func() {
 		testJSON := `{"links":{"self":{"href":"/datasets/12345"}}}`
 		transp := dummyRT{testJSON}


### PR DESCRIPTION
### What
- Do not rewrite URL's that don't need it
The API router rewrites the hostname of URL's, to replace them with the API router URL. If a URL is already correct the API router would still rewrite the URL, causing it to duplicate the version. This is why some API responses have '/v1/v1' in URL's.

### How to review
Review changes / tests

### Who can review
Anyone
