### PR TITLE
Revert transitional nomad job name

### DIFF
--- a/dp-api-router.nomad
+++ b/dp-api-router.nomad
@@ -1,4 +1,4 @@
-job "dp-api-router-system" {
+job "dp-api-router" {
   datacenters = ["eu-west-1"]
   region      = "eu"
   type        = "system"


### PR DESCRIPTION
### What

Revert the transitional job name as the deployer assumes the job always matches the app name.

### Who can review

Anyone but me.
