### PR TITLE
update search-api URL to point new search-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This service is responsible for serving a JSON-LD `@context` field on configured
 | RECIPE_API_URL               | "http://localhost:22300"                  | A URL to the recipe api
 | CODE_LIST_API_URL            | "http://localhost:22400"                  | A URL to the code list api
 | HIERARCHY_API_URL            | "http://localhost:22600"                  | A URL to the hierarchy api
-| SEARCH_API_URL               | "http://localhost:23100"                  | A URL to the search api
+| SEARCH_API_URL               | "http://localhost:23900"                  | A URL to the search api
 | DIMENSION_SEARCH_API_URL     | "http://localhost:23100"                  | A URL to the dimension search api
 | SESSIONS_API_URL             | "http://localhost:24400"                  | A URL to the sessions api
 | OBSERVATION_API_URL          | "http://localhost:24500"                  | A URL to the observation api

--- a/config/config.go
+++ b/config/config.go
@@ -67,7 +67,7 @@ func Get() (*Config, error) {
 			CodelistAPIURL:             "http://localhost:22400",
 			RecipeAPIURL:               "http://localhost:22300",
 			ImportAPIURL:               "http://localhost:21800",
-			SearchAPIURL:               "http://localhost:23100",
+			SearchAPIURL:               "http://localhost:23900",
 			DimensionSearchAPIURL:      "http://localhost:23100",
 			ImageAPIURL:                "http://localhost:24700",
 			UploadServiceAPIURL:        "http://localhost:25100",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -29,7 +29,7 @@ func TestGetRetrunsDefaultValues(t *testing.T) {
 			ImportAPIURL:               "http://localhost:21800",
 			ImageAPIURL:                "http://localhost:24700",
 			UploadServiceAPIURL:        "http://localhost:25100",
-			SearchAPIURL:               "http://localhost:23100",
+			SearchAPIURL:               "http://localhost:23900",
 			DimensionSearchAPIURL:      "http://localhost:23100",
 			APIPocURL:                  "http://localhost:3000",
 			ContextURL:                 "",


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- Update SEARCH_API_URL to point to new `dp-search-api` (previously known as `dp-search-query`)
- Please note that the secret of dp-api-router will be updated for this change and this is in the PR (https://github.com/ONSdigital/dp-configs/pull/266)

### How to review
**Describe the steps required to test the changes.**
- Check if the code changes make sense
- Check if the tests pass

### Who can review
**Describe who worked on the changes, so that other people can review.**
Anyone