### PR TITLE
Feature/identity api routing

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	DimensionSearchAPIURL      string        `envconfig:"DIMENSION_SEARCH_API_URL"`
 	ImageAPIURL                string        `envconfig:"IMAGE_API_URL"`
 	UploadServiceAPIURL        string        `envconfig:"UPLOAD_SERVICE_API_URL"`
+	IdentityAPIURL             string        `envconfig:"IDENTITY_API_URL"`
 	ContextURL                 string        `envconfig:"CONTEXT_URL"`
 	EnvironmentHost            string        `envconfig:"ENV_HOST"`
 	APIPocURL                  string        `envconfig:"API_POC_URL"`
@@ -71,6 +72,7 @@ func Get() (*Config, error) {
 			DimensionSearchAPIURL:      "http://localhost:23100",
 			ImageAPIURL:                "http://localhost:24700",
 			UploadServiceAPIURL:        "http://localhost:25100",
+			IdentityAPIURL:             "http://localhost:25600",
 			APIPocURL:                  "http://localhost:3000",
 			ContextURL:                 "",
 			EnvironmentHost:            "http://localhost:23200",

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	ImageAPIURL                string        `envconfig:"IMAGE_API_URL"`
 	UploadServiceAPIURL        string        `envconfig:"UPLOAD_SERVICE_API_URL"`
 	IdentityAPIURL             string        `envconfig:"IDENTITY_API_URL"`
+	IdentityAPIVersions        []string      `envconfig:"IDENTITY_API_VERSIONS"`
 	ContextURL                 string        `envconfig:"CONTEXT_URL"`
 	EnvironmentHost            string        `envconfig:"ENV_HOST"`
 	APIPocURL                  string        `envconfig:"API_POC_URL"`
@@ -73,6 +74,7 @@ func Get() (*Config, error) {
 			ImageAPIURL:                "http://localhost:24700",
 			UploadServiceAPIURL:        "http://localhost:25100",
 			IdentityAPIURL:             "http://localhost:25600",
+			IdentityAPIVersions:        []string{"v1"},
 			APIPocURL:                  "http://localhost:3000",
 			ContextURL:                 "",
 			EnvironmentHost:            "http://localhost:23200",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -29,6 +29,8 @@ func TestGetRetrunsDefaultValues(t *testing.T) {
 			ImportAPIURL:               "http://localhost:21800",
 			ImageAPIURL:                "http://localhost:24700",
 			UploadServiceAPIURL:        "http://localhost:25100",
+			IdentityAPIURL:             "http://localhost:25600",
+			IdentityAPIVersions:        []string{"v1"},
 			SearchAPIURL:               "http://localhost:23900",
 			DimensionSearchAPIURL:      "http://localhost:23100",
 			APIPocURL:                  "http://localhost:3000",

--- a/middleware/audit.go
+++ b/middleware/audit.go
@@ -56,7 +56,7 @@ func ShallSkipIdentity(versionPrefix, path string) bool {
 
 func shallIgnore(path string) bool {
 	for _, pathToIgnore := range pathsToIgnore {
-		if path == pathToIgnore {
+		if strings.HasPrefix(path, pathToIgnore) {
 			return true
 		}
 	}

--- a/middleware/audit.go
+++ b/middleware/audit.go
@@ -29,10 +29,14 @@ type Router interface {
 }
 
 // paths that will skip auditing (note)
+// identity api paths being added until the auditing has been updated to work with new tokens
 var pathsToIgnore = []string{
 	"/ping",
 	"/clickEventLog",
 	"/health",
+	"/v1/tokens",
+	"/v1/users",
+	"/v1/groups",
 }
 
 // paths that will skip retrieveIdentity, and will be audited without identity

--- a/middleware/audit.go
+++ b/middleware/audit.go
@@ -30,6 +30,7 @@ type Router interface {
 
 // paths that will skip auditing (note)
 // identity api paths being added until the auditing has been updated to work with new tokens
+// TODO remove "/v1/tokens", "/v1/users", "/v1/groups", "/v1/password-reset" from this list once authorisation has been integrated into dp-identity-api
 var pathsToIgnore = []string{
 	"/ping",
 	"/clickEventLog",

--- a/middleware/audit.go
+++ b/middleware/audit.go
@@ -37,6 +37,7 @@ var pathsToIgnore = []string{
 	"/v1/tokens",
 	"/v1/users",
 	"/v1/groups",
+	"/v1/password-reset",
 }
 
 // paths that will skip retrieveIdentity, and will be audited without identity

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -49,8 +49,8 @@ func (p *APIProxy) Handle(w http.ResponseWriter, r *http.Request) {
 	p.proxy.ServeHTTP(w, r)
 }
 
-// VersionHandle removes the /v1 path item from the URL and then calls the proxy's ServeHTTP
-func (p *APIProxy) VersionHandle(w http.ResponseWriter, r *http.Request) {
+// LegacyHandle removes the /v1 path item from the URL and then calls the proxy's ServeHTTP
+func (p *APIProxy) LegacyHandle(w http.ResponseWriter, r *http.Request) {
 	r.URL.Path = strings.Replace(r.URL.Path, "/v1", "", 1)
 
 	middleware.BetaApiHandler(p.enableBetaRestriction, p.proxy).ServeHTTP(w, r)

--- a/service/service.go
+++ b/service/service.go
@@ -176,19 +176,19 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 	addLegacyHandler(router, poc, "/search")
 
 	zebedee := proxy.NewAPIProxy(cfg.ZebedeeURL, cfg.Version, cfg.EnvironmentHost, "", false)
-	router.NotFoundHandler = http.HandlerFunc(zebedee.VersionHandle)
+	router.NotFoundHandler = http.HandlerFunc(zebedee.LegacyHandle)
 
 	return router
 }
 
 func addVersionHandler(router *mux.Router, proxy *proxy.APIProxy, path string) {
 	// Proxy any request after the path given to the target address
-	router.HandleFunc(fmt.Sprintf("/%s"+path+"{rest:.*}", proxy.Version), proxy.VersionHandle)
+	router.HandleFunc(fmt.Sprintf("/%s"+path+"{rest:.*}", proxy.Version), proxy.LegacyHandle)
 }
 
 func addLegacyHandler(router *mux.Router, proxy *proxy.APIProxy, path string) {
 	// Proxy any request after the path given to the target address
-	router.HandleFunc(path+"{rest:.*}", proxy.VersionHandle)
+	router.HandleFunc(path+"{rest:.*}", proxy.LegacyHandle)
 }
 
 // Close gracefully shuts the service down in the required order, with timeout

--- a/service/service.go
+++ b/service/service.go
@@ -161,12 +161,10 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		addTransitionalHandler(router, importAPI, "/jobs")
 		addTransitionalHandler(router, dataset, "/instances")
 		addTransitionalHandler(router, uploadServiceAPI, "/upload")
-		for _, version := range cfg.IdentityAPIVersions {
-			addVersionedHandler(router, identityAPI, version, "/tokens")
-			addVersionedHandler(router, identityAPI, version, "/users")
-			addVersionedHandler(router, identityAPI, version, "/groups")
-			addVersionedHandler(router, identityAPI, version, "/password-reset")
-		}
+		addVersionedHandlers(router, identityAPI, cfg.IdentityAPIVersions, "/tokens")
+		addVersionedHandlers(router, identityAPI, cfg.IdentityAPIVersions, "/users")
+		addVersionedHandlers(router, identityAPI, cfg.IdentityAPIVersions, "/groups")
+		addVersionedHandlers(router, identityAPI, cfg.IdentityAPIVersions, "/password-reset")
 
 		// Feature flag for Sessions API
 		if cfg.EnableSessionsAPI {
@@ -188,9 +186,11 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 	return router
 }
 
-func addVersionedHandler(router *mux.Router, proxy *proxy.APIProxy, version string, path string) {
+func addVersionedHandlers(router *mux.Router, proxy *proxy.APIProxy, versions []string, path string) {
 	// Proxy any request after the path given to the target address
-	router.HandleFunc("/"+version+path+"{rest:.*}", proxy.Handle)
+	for _, version := range versions {
+		router.HandleFunc("/"+version+path+"{rest:.*}", proxy.Handle)
+	}
 }
 
 func addTransitionalHandler(router *mux.Router, proxy *proxy.APIProxy, path string) {

--- a/service/service.go
+++ b/service/service.go
@@ -129,11 +129,11 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 	// Public APIs
 	if cfg.EnableObservationAPI {
 		observation := proxy.NewAPIProxy(cfg.ObservationAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
-		addVersionHandler(router, observation, "/datasets/{dataset_id}/editions/{edition}/versions/{version}/observations")
+		addTransitionalHandler(router, observation, "/datasets/{dataset_id}/editions/{edition}/versions/{version}/observations")
 	}
 	if cfg.EnableTopicAPI {
 		topic := proxy.NewAPIProxy(cfg.TopicAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
-		addVersionHandler(router, topic, "/topics")
+		addTransitionalHandler(router, topic, "/topics")
 	}
 	codeList := proxy.NewAPIProxy(cfg.CodelistAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	dataset := proxy.NewAPIProxy(cfg.DatasetAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
@@ -156,10 +156,16 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		recipe := proxy.NewAPIProxy(cfg.RecipeAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		importAPI := proxy.NewAPIProxy(cfg.ImportAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		uploadServiceAPI := proxy.NewAPIProxy(cfg.UploadServiceAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+		identityAPI := proxy.NewAPIProxy(cfg.IdentityAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		addTransitionalHandler(router, recipe, "/recipes")
 		addTransitionalHandler(router, importAPI, "/jobs")
 		addTransitionalHandler(router, dataset, "/instances")
 		addTransitionalHandler(router, uploadServiceAPI, "/upload")
+		for _, version := range cfg.IdentityAPIVersions {
+			addVersionedHandler(router, identityAPI, version, "/tokens")
+			addVersionedHandler(router, identityAPI, version, "/users")
+			addVersionedHandler(router, identityAPI, version, "/groups")
+		}
 
 		// Feature flag for Sessions API
 		if cfg.EnableSessionsAPI {

--- a/service/service.go
+++ b/service/service.go
@@ -152,7 +152,6 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 	addTransitionalHandler(router, image, "/images")
 
 	// Private APIs
-	fmt.Println("private endpoint config - "+fmt.Sprintf("%v", cfg.EnablePrivateEndpoints))
 	if cfg.EnablePrivateEndpoints {
 		recipe := proxy.NewAPIProxy(cfg.RecipeAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		importAPI := proxy.NewAPIProxy(cfg.ImportAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)

--- a/service/service.go
+++ b/service/service.go
@@ -152,6 +152,7 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 	addTransitionalHandler(router, image, "/images")
 
 	// Private APIs
+	fmt.Println("private endpoint config - "+fmt.Sprintf("%v", cfg.EnablePrivateEndpoints))
 	if cfg.EnablePrivateEndpoints {
 		recipe := proxy.NewAPIProxy(cfg.RecipeAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		importAPI := proxy.NewAPIProxy(cfg.ImportAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
@@ -165,6 +166,7 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 			addVersionedHandler(router, identityAPI, version, "/tokens")
 			addVersionedHandler(router, identityAPI, version, "/users")
 			addVersionedHandler(router, identityAPI, version, "/groups")
+			addVersionedHandler(router, identityAPI, version, "/password-reset")
 		}
 
 		// Feature flag for Sessions API

--- a/service/service.go
+++ b/service/service.go
@@ -142,29 +142,29 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 	search := proxy.NewAPIProxy(cfg.SearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	dimensionSearch := proxy.NewAPIProxy(cfg.DimensionSearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	image := proxy.NewAPIProxy(cfg.ImageAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-	addVersionHandler(router, codeList, "/code-lists")
-	addVersionHandler(router, dataset, "/datasets")
-	addVersionHandler(router, filter, "/filters")
-	addVersionHandler(router, filter, "/filter-outputs")
-	addVersionHandler(router, hierarchy, "/hierarchies")
-	addVersionHandler(router, search, "/search")
-	addVersionHandler(router, dimensionSearch, "/dimension-search")
-	addVersionHandler(router, image, "/images")
+	addTransitionalHandler(router, codeList, "/code-lists")
+	addTransitionalHandler(router, dataset, "/datasets")
+	addTransitionalHandler(router, filter, "/filters")
+	addTransitionalHandler(router, filter, "/filter-outputs")
+	addTransitionalHandler(router, hierarchy, "/hierarchies")
+	addTransitionalHandler(router, search, "/search")
+	addTransitionalHandler(router, dimensionSearch, "/dimension-search")
+	addTransitionalHandler(router, image, "/images")
 
 	// Private APIs
 	if cfg.EnablePrivateEndpoints {
 		recipe := proxy.NewAPIProxy(cfg.RecipeAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		importAPI := proxy.NewAPIProxy(cfg.ImportAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		uploadServiceAPI := proxy.NewAPIProxy(cfg.UploadServiceAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-		addVersionHandler(router, recipe, "/recipes")
-		addVersionHandler(router, importAPI, "/jobs")
-		addVersionHandler(router, dataset, "/instances")
-		addVersionHandler(router, uploadServiceAPI, "/upload")
+		addTransitionalHandler(router, recipe, "/recipes")
+		addTransitionalHandler(router, importAPI, "/jobs")
+		addTransitionalHandler(router, dataset, "/instances")
+		addTransitionalHandler(router, uploadServiceAPI, "/upload")
 
 		// Feature flag for Sessions API
 		if cfg.EnableSessionsAPI {
 			session := proxy.NewAPIProxy(cfg.SessionsAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-			addVersionHandler(router, session, "/sessions")
+			addTransitionalHandler(router, session, "/sessions")
 		}
 	}
 
@@ -182,6 +182,7 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 }
 
 func addVersionHandler(router *mux.Router, proxy *proxy.APIProxy, path string) {
+func addTransitionalHandler(router *mux.Router, proxy *proxy.APIProxy, path string) {
 	// Proxy any request after the path given to the target address
 	router.HandleFunc(fmt.Sprintf("/%s"+path+"{rest:.*}", proxy.Version), proxy.LegacyHandle)
 }

--- a/service/service.go
+++ b/service/service.go
@@ -181,7 +181,11 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 	return router
 }
 
-func addVersionHandler(router *mux.Router, proxy *proxy.APIProxy, path string) {
+func addVersionedHandler(router *mux.Router, proxy *proxy.APIProxy, version string, path string) {
+	// Proxy any request after the path given to the target address
+	router.HandleFunc("/"+version+path+"{rest:.*}", proxy.Handle)
+}
+
 func addTransitionalHandler(router *mux.Router, proxy *proxy.APIProxy, path string) {
 	// Proxy any request after the path given to the target address
 	router.HandleFunc(fmt.Sprintf("/%s"+path+"{rest:.*}", proxy.Version), proxy.LegacyHandle)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -226,6 +226,8 @@ func TestRouterPrivateAPIs(t *testing.T) {
 		So(err, ShouldBeNil)
 		uploadServiceAPIURL, err := url.Parse(cfg.UploadServiceAPIURL)
 		So(err, ShouldBeNil)
+		identityAPIURL, err := url.Parse(cfg.IdentityAPIURL)
+		So(err, ShouldBeNil)
 		zebedeeURL, err := url.Parse(cfg.ZebedeeURL)
 		So(err, ShouldBeNil)
 
@@ -234,6 +236,14 @@ func TestRouterPrivateAPIs(t *testing.T) {
 			"/recipes":   recipeAPIURL,
 			"/jobs":      importAPIURL,
 			"/instances": datasetAPIURL,
+		}
+		for _, version := range cfg.IdentityAPIVersions {
+			key := "/"+version+"/tokens"
+			expectedPrivateURLs[key] = identityAPIURL
+			key = "/"+version+"/users"
+			expectedPrivateURLs[key] = identityAPIURL
+			key = "/"+version+"/groups"
+			expectedPrivateURLs[key] = identityAPIURL
 		}
 
 		resetProxyMocksWithExpectations(expectedPrivateURLs)
@@ -287,6 +297,54 @@ func TestRouterPrivateAPIs(t *testing.T) {
 				w := createRouterTest(cfg, "http://localhost:23200/v1/instances/subpath")
 				So(w.Code, ShouldEqual, http.StatusOK)
 				verifyProxied("/instances/subpath", datasetAPIURL)
+			})
+
+			Convey("A request to a tokens path is proxied to identityAPIURL", func() {
+				for _, version := range cfg.IdentityAPIVersions {
+					w := createRouterTest(cfg, "http://localhost:23200/"+version+"/tokens")
+					So(w.Code, ShouldEqual, http.StatusOK)
+					verifyProxied("/"+version+"/tokens", identityAPIURL)
+				}
+			})
+
+			Convey("A request to a tokens subpath is proxied to identityAPIURL", func() {
+				for _, version := range cfg.IdentityAPIVersions {
+					w := createRouterTest(cfg, "http://localhost:23200/"+version+"/tokens/subpath")
+					So(w.Code, ShouldEqual, http.StatusOK)
+					verifyProxied("/"+version+"/tokens/subpath", identityAPIURL)
+				}
+			})
+
+			Convey("A request to a users path is proxied to identityAPIURL", func() {
+				for _, version := range cfg.IdentityAPIVersions {
+					w := createRouterTest(cfg, "http://localhost:23200/"+version+"/users")
+					So(w.Code, ShouldEqual, http.StatusOK)
+					verifyProxied("/"+version+"/users", identityAPIURL)
+				}
+			})
+
+			Convey("A request to a users subpath is proxied to identityAPIURL", func() {
+				for _, version := range cfg.IdentityAPIVersions {
+					w := createRouterTest(cfg, "http://localhost:23200/"+version+"/users/subpath")
+					So(w.Code, ShouldEqual, http.StatusOK)
+					verifyProxied("/"+version+"/users/subpath", identityAPIURL)
+				}
+			})
+
+			Convey("A request to a groups path is proxied to identityAPIURL", func() {
+				for _, version := range cfg.IdentityAPIVersions {
+					w := createRouterTest(cfg, "http://localhost:23200/"+version+"/groups")
+					So(w.Code, ShouldEqual, http.StatusOK)
+					verifyProxied("/"+version+"/groups", identityAPIURL)
+				}
+			})
+
+			Convey("A request to a groups subpath is proxied to identityAPIURL", func() {
+				for _, version := range cfg.IdentityAPIVersions {
+					w := createRouterTest(cfg, "http://localhost:23200/"+version+"/groups/subpath")
+					So(w.Code, ShouldEqual, http.StatusOK)
+					verifyProxied("/"+version+"/groups/subpath", identityAPIURL)
+				}
 			})
 		})
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -2,6 +2,7 @@ package service_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -244,6 +245,8 @@ func TestRouterPrivateAPIs(t *testing.T) {
 			expectedPrivateURLs[key] = identityAPIURL
 			key = "/"+version+"/groups"
 			expectedPrivateURLs[key] = identityAPIURL
+			key = "/"+version+"/password-reset"
+			expectedPrivateURLs[key] = identityAPIURL
 		}
 
 		resetProxyMocksWithExpectations(expectedPrivateURLs)
@@ -344,6 +347,15 @@ func TestRouterPrivateAPIs(t *testing.T) {
 					w := createRouterTest(cfg, "http://localhost:23200/"+version+"/groups/subpath")
 					So(w.Code, ShouldEqual, http.StatusOK)
 					verifyProxied("/"+version+"/groups/subpath", identityAPIURL)
+				}
+			})
+
+			Convey("A request to password-reset path is proxied to identityAPIURL", func() {
+				fmt.Println(cfg.IdentityAPIVersions)
+				for _, version := range cfg.IdentityAPIVersions {
+					w := createRouterTest(cfg, "http://localhost:23200/"+version+"/password-reset")
+					So(w.Code, ShouldEqual, http.StatusOK)
+					verifyProxied("/"+version+"/password-reset", identityAPIURL)
 				}
 			})
 		})

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -2,7 +2,6 @@ package service_test
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -351,7 +350,6 @@ func TestRouterPrivateAPIs(t *testing.T) {
 			})
 
 			Convey("A request to password-reset path is proxied to identityAPIURL", func() {
-				fmt.Println(cfg.IdentityAPIVersions)
 				for _, version := range cfg.IdentityAPIVersions {
 					w := createRouterTest(cfg, "http://localhost:23200/"+version+"/password-reset")
 					So(w.Code, ShouldEqual, http.StatusOK)


### PR DESCRIPTION
### What

Added support for versioned paths on apis and router requests
Added paths for the dp-identity-api

### How to review

Check the tests are passing.
Run the router with the identity-api, send a PUT request to /v1/tokens/self, you should receive a 400 response with 2 'InvalidToken' errors because no refresh or id tokens have been sent.

### Who can review

@janderson2 
