### PR TITLE
add update body ignore for debugging nginx failure location

### DIFF
--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -67,8 +67,10 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 		return nil, err
 	}
 
-	log.Event(req.Context(), "could not update response body with correct links", log.INFO, log.Data{"body": resp.Body})
-	if !shallIgnore(req.RequestURI){
+	if shallIgnore(req.RequestURI) {
+		log.Event(req.Context(), "debugging path", log.INFO, log.Data{"body": req.RequestURI})
+		log.Event(req.Context(), "debugging body", log.INFO, log.Data{"body": resp.Body})
+	} else {
 		b, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err

--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -67,7 +67,7 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 		return nil, err
 	}
 
-	fmt.Println(resp.Body)
+	log.Event(req.Context(), "could not update response body with correct links", log.INFO, log.Data{"body": resp.Body})
 	if !shallIgnore(req.RequestURI){
 		b, err := ioutil.ReadAll(resp.Body)
 		if err != nil {

--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -63,11 +63,12 @@ func shallIgnore(path string) bool {
 // host to links
 func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
 	resp, err = t.RoundTripper.RoundTrip(req)
-	if !shallIgnore(req.RequestURI){
-		if err != nil {
-			return nil, err
-		}
+	if err != nil {
+		return nil, err
+	}
 
+	fmt.Println(resp.Body)
+	if !shallIgnore(req.RequestURI){
 		b, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err

--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -43,42 +43,60 @@ var (
 	re = regexp.MustCompile(`^(.+://)(.+)(/v\d)$`)
 )
 
+var pathsToIgnore = []string{
+	"/v1/tokens",
+	"/v1/users",
+	"/v1/groups",
+	"/v1/password-reset",
+}
+
+func shallIgnore(path string) bool {
+	for _, pathToIgnore := range pathsToIgnore {
+		if strings.HasPrefix(path, pathToIgnore) {
+			return true
+		}
+	}
+	return false
+}
+
 // RoundTrip intercepts the response body and post processes to add the correct enviornment
 // host to links
 func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
 	resp, err = t.RoundTripper.RoundTrip(req)
-	if err != nil {
-		return nil, err
-	}
+	if !shallIgnore(req.RequestURI){
+		if err != nil {
+			return nil, err
+		}
 
-	b, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	err = resp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		err = resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
 
-	if len(b) == 0 {
-		resp.Body = ioutil.NopCloser(bytes.NewReader([]byte{}))
-		return resp, nil
-	}
+		if len(b) == 0 {
+			resp.Body = ioutil.NopCloser(bytes.NewReader([]byte{}))
+			return resp, nil
+		}
 
-	updatedB, err := t.update(b)
-	if err != nil {
-		log.Event(req.Context(), "could not update response body with correct links", log.ERROR, log.Error(err))
-		body := ioutil.NopCloser(bytes.NewReader(b))
+		updatedB, err := t.update(b)
+		if err != nil {
+			log.Event(req.Context(), "could not update response body with correct links", log.ERROR, log.Error(err))
+			body := ioutil.NopCloser(bytes.NewReader(b))
+
+			resp.Body = body
+			return resp, nil
+		}
+
+		body := ioutil.NopCloser(bytes.NewReader(updatedB))
 
 		resp.Body = body
-		return resp, nil
+		resp.ContentLength = int64(len(updatedB))
+		resp.Header.Set("Content-Length", strconv.Itoa(len(updatedB)))
 	}
-
-	body := ioutil.NopCloser(bytes.NewReader(updatedB))
-
-	resp.Body = body
-	resp.ContentLength = int64(len(updatedB))
-	resp.Header.Set("Content-Length", strconv.Itoa(len(updatedB)))
 	return resp, nil
 }
 

--- a/interceptor/interceptor_test.go
+++ b/interceptor/interceptor_test.go
@@ -33,7 +33,7 @@ func TestUnitInterceptor(t *testing.T) {
 
 		t := NewRoundTripper(testDomain, "", transp)
 
-		resp, err := t.RoundTrip(nil)
+		resp, err := t.RoundTrip(&http.Request{})
 		So(err, ShouldBeNil)
 
 		b, _ := ioutil.ReadAll(resp.Body)
@@ -49,7 +49,7 @@ func TestUnitInterceptor(t *testing.T) {
 
 		t := NewRoundTripper(testDomain, "", transp)
 
-		resp, err := t.RoundTrip(nil)
+		resp, err := t.RoundTrip(&http.Request{})
 		So(err, ShouldBeNil)
 
 		b, _ := ioutil.ReadAll(resp.Body)
@@ -65,7 +65,7 @@ func TestUnitInterceptor(t *testing.T) {
 
 		t := NewRoundTripper(testDomain, "", transp)
 
-		resp, err := t.RoundTrip(nil)
+		resp, err := t.RoundTrip(&http.Request{})
 		So(err, ShouldBeNil)
 
 		b, _ := ioutil.ReadAll(resp.Body)
@@ -82,7 +82,7 @@ func TestUnitInterceptor(t *testing.T) {
 
 		t := NewRoundTripper(testDomain, testContext, transp)
 
-		resp, err := t.RoundTrip(nil)
+		resp, err := t.RoundTrip(&http.Request{})
 		So(err, ShouldBeNil)
 
 		b, _ := ioutil.ReadAll(resp.Body)
@@ -99,7 +99,7 @@ func TestUnitInterceptor(t *testing.T) {
 
 		t := NewRoundTripper(testDomain, "", transp)
 
-		resp, err := t.RoundTrip(nil)
+		resp, err := t.RoundTrip(&http.Request{})
 		So(err, ShouldBeNil)
 
 		b, _ := ioutil.ReadAll(resp.Body)
@@ -116,7 +116,7 @@ func TestUnitInterceptor(t *testing.T) {
 
 		t := NewRoundTripper(testDomain, "", transp)
 
-		resp, err := t.RoundTrip(nil)
+		resp, err := t.RoundTrip(&http.Request{})
 		So(err, ShouldBeNil)
 
 		b, _ := ioutil.ReadAll(resp.Body)
@@ -132,7 +132,7 @@ func TestUnitInterceptor(t *testing.T) {
 
 		t := NewRoundTripper(testDomain, "", transp)
 
-		resp, err := t.RoundTrip(nil)
+		resp, err := t.RoundTrip(&http.Request{})
 		So(err, ShouldBeNil)
 
 		b, _ := ioutil.ReadAll(resp.Body)
@@ -148,7 +148,7 @@ func TestUnitInterceptor(t *testing.T) {
 
 		t := NewRoundTripper(testDomain, "", transp)
 
-		resp, err := t.RoundTrip(nil)
+		resp, err := t.RoundTrip(&http.Request{})
 		So(err, ShouldBeNil)
 
 		b, _ := ioutil.ReadAll(resp.Body)
@@ -164,7 +164,7 @@ func TestUnitInterceptor(t *testing.T) {
 
 		t := NewRoundTripper(testDomain, "", transp)
 
-		resp, err := t.RoundTrip(nil)
+		resp, err := t.RoundTrip(&http.Request{})
 		So(err, ShouldBeNil)
 
 		b, _ := ioutil.ReadAll(resp.Body)
@@ -180,7 +180,7 @@ func TestUnitInterceptor(t *testing.T) {
 
 		t := NewRoundTripper(testDomain, "", transp)
 
-		resp, err := t.RoundTrip(nil)
+		resp, err := t.RoundTrip(&http.Request{})
 		So(err, ShouldBeNil)
 
 		b, _ := ioutil.ReadAll(resp.Body)
@@ -196,7 +196,7 @@ func TestUnitInterceptor(t *testing.T) {
 
 		t := NewRoundTripper(testDomain, "", transp)
 
-		resp, err := t.RoundTrip(nil)
+		resp, err := t.RoundTrip(&http.Request{})
 		So(err, ShouldBeNil)
 
 		b, _ := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
### What

Exclude the the dp-identity-api requests from the body update process to debug where the responses are failing.

### How to review

Read through the changes

### Who can review

Anyone but me
