### PR TITLE
Only unmarshal json and map, code clean up, restrict log length of body

### DIFF
--- a/event/producer_test.go
+++ b/event/producer_test.go
@@ -96,8 +96,8 @@ func TestAvroProducer(t *testing.T) {
 
 // Unmarshal converts observation events to []byte.
 func unmarshal(bytes []byte) *event.Audit {
-	event := &event.Audit{}
-	err := schema.AuditEvent.Unmarshal(bytes, event)
+	observationEvent := &event.Audit{}
+	err := schema.AuditEvent.Unmarshal(bytes, observationEvent)
 	So(err, ShouldBeNil)
-	return event
+	return observationEvent
 }

--- a/interceptor/interceptor_test.go
+++ b/interceptor/interceptor_test.go
@@ -206,4 +206,21 @@ func TestUnitInterceptor(t *testing.T) {
 		So(len(b), ShouldEqual, 154)
 		So(string(b), ShouldEqual, `[{"links":{"self":{"href":"https://api.beta.ons.gov.uk/v1/datasets/12345"}}},{"links":{"self":{"href":"https://api.beta.ons.gov.uk/v1/datasets/12345"}}}]`+"\n")
 	})
+
+	Convey("test interceptor correctly ignores non json and non map object", t, func() {
+		testJSON := `AA`
+		transp := dummyRT{testJSON}
+
+		t := NewRoundTripper(testDomain, "", transp)
+
+		resp, err := t.RoundTrip(&http.Request{})
+		So(err, ShouldBeNil)
+
+		b, _ := ioutil.ReadAll(resp.Body)
+
+		err = resp.Body.Close()
+		So(err, ShouldBeNil)
+		So(len(b), ShouldEqual, 2)
+		So(string(b), ShouldEqual, `AA`)
+	})
 }

--- a/interceptor/interceptor_test.go
+++ b/interceptor/interceptor_test.go
@@ -18,6 +18,7 @@ type dummyRT struct {
 }
 
 func (t dummyRT) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+	_ = req // shut some linters up
 	resp = httptest.NewRecorder().Result()
 	resp.Body = ioutil.NopCloser(strings.NewReader(t.testJSON))
 	return
@@ -36,7 +37,8 @@ func TestUnitInterceptor(t *testing.T) {
 		resp, err := t.RoundTrip(&http.Request{})
 		So(err, ShouldBeNil)
 
-		b, _ := ioutil.ReadAll(resp.Body)
+		b, err := ioutil.ReadAll(resp.Body)
+		So(err, ShouldBeNil)
 
 		err = resp.Body.Close()
 		So(err, ShouldBeNil)
@@ -52,7 +54,8 @@ func TestUnitInterceptor(t *testing.T) {
 		resp, err := t.RoundTrip(&http.Request{})
 		So(err, ShouldBeNil)
 
-		b, _ := ioutil.ReadAll(resp.Body)
+		b, err := ioutil.ReadAll(resp.Body)
+		So(err, ShouldBeNil)
 
 		err = resp.Body.Close()
 		So(err, ShouldBeNil)
@@ -68,7 +71,8 @@ func TestUnitInterceptor(t *testing.T) {
 		resp, err := t.RoundTrip(&http.Request{})
 		So(err, ShouldBeNil)
 
-		b, _ := ioutil.ReadAll(resp.Body)
+		b, err := ioutil.ReadAll(resp.Body)
+		So(err, ShouldBeNil)
 
 		err = resp.Body.Close()
 		So(err, ShouldBeNil)
@@ -85,7 +89,8 @@ func TestUnitInterceptor(t *testing.T) {
 		resp, err := t.RoundTrip(&http.Request{})
 		So(err, ShouldBeNil)
 
-		b, _ := ioutil.ReadAll(resp.Body)
+		b, err := ioutil.ReadAll(resp.Body)
+		So(err, ShouldBeNil)
 
 		err = resp.Body.Close()
 		So(err, ShouldBeNil)
@@ -102,7 +107,8 @@ func TestUnitInterceptor(t *testing.T) {
 		resp, err := t.RoundTrip(&http.Request{})
 		So(err, ShouldBeNil)
 
-		b, _ := ioutil.ReadAll(resp.Body)
+		b, err := ioutil.ReadAll(resp.Body)
+		So(err, ShouldBeNil)
 
 		err = resp.Body.Close()
 		So(err, ShouldBeNil)
@@ -119,7 +125,9 @@ func TestUnitInterceptor(t *testing.T) {
 		resp, err := t.RoundTrip(&http.Request{})
 		So(err, ShouldBeNil)
 
-		b, _ := ioutil.ReadAll(resp.Body)
+		b, err := ioutil.ReadAll(resp.Body)
+		So(err, ShouldBeNil)
+
 		err = resp.Body.Close()
 		So(err, ShouldBeNil)
 		So(len(b), ShouldEqual, 77)
@@ -135,7 +143,9 @@ func TestUnitInterceptor(t *testing.T) {
 		resp, err := t.RoundTrip(&http.Request{})
 		So(err, ShouldBeNil)
 
-		b, _ := ioutil.ReadAll(resp.Body)
+		b, err := ioutil.ReadAll(resp.Body)
+		So(err, ShouldBeNil)
+
 		err = resp.Body.Close()
 		So(err, ShouldBeNil)
 		So(len(b), ShouldEqual, 88)
@@ -151,7 +161,9 @@ func TestUnitInterceptor(t *testing.T) {
 		resp, err := t.RoundTrip(&http.Request{})
 		So(err, ShouldBeNil)
 
-		b, _ := ioutil.ReadAll(resp.Body)
+		b, err := ioutil.ReadAll(resp.Body)
+		So(err, ShouldBeNil)
+
 		err = resp.Body.Close()
 		So(err, ShouldBeNil)
 		So(len(b), ShouldEqual, 83)
@@ -167,7 +179,9 @@ func TestUnitInterceptor(t *testing.T) {
 		resp, err := t.RoundTrip(&http.Request{})
 		So(err, ShouldBeNil)
 
-		b, _ := ioutil.ReadAll(resp.Body)
+		b, err := ioutil.ReadAll(resp.Body)
+		So(err, ShouldBeNil)
+
 		err = resp.Body.Close()
 		So(err, ShouldBeNil)
 		So(len(b), ShouldEqual, 91)
@@ -183,7 +197,9 @@ func TestUnitInterceptor(t *testing.T) {
 		resp, err := t.RoundTrip(&http.Request{})
 		So(err, ShouldBeNil)
 
-		b, _ := ioutil.ReadAll(resp.Body)
+		b, err := ioutil.ReadAll(resp.Body)
+		So(err, ShouldBeNil)
+
 		err = resp.Body.Close()
 		So(err, ShouldBeNil)
 		So(len(b), ShouldEqual, 116)
@@ -199,7 +215,8 @@ func TestUnitInterceptor(t *testing.T) {
 		resp, err := t.RoundTrip(&http.Request{})
 		So(err, ShouldBeNil)
 
-		b, _ := ioutil.ReadAll(resp.Body)
+		b, err := ioutil.ReadAll(resp.Body)
+		So(err, ShouldBeNil)
 
 		err = resp.Body.Close()
 		So(err, ShouldBeNil)
@@ -216,7 +233,8 @@ func TestUnitInterceptor(t *testing.T) {
 		resp, err := t.RoundTrip(&http.Request{})
 		So(err, ShouldBeNil)
 
-		b, _ := ioutil.ReadAll(resp.Body)
+		b, err := ioutil.ReadAll(resp.Body)
+		So(err, ShouldBeNil)
 
 		err = resp.Body.Close()
 		So(err, ShouldBeNil)

--- a/main.go
+++ b/main.go
@@ -59,7 +59,9 @@ func run(ctx context.Context) error {
 	case sig := <-signals:
 		ctx := context.Background()
 		log.Info(ctx, "os signal received", log.Data{"signal": sig})
-		svc.Close(ctx)
+		if err = svc.Close(ctx); err != nil {
+			log.Error(ctx, "service Close error", err)
+		}
 	}
 	return nil
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ONSdigital/log.go/v2/log"
 )
 
-// APIProxy will forward any requests to a API
+// APIProxy will forward any requests to an API
 type APIProxy struct {
 	target                *url.URL
 	proxy                 IReverseProxy
@@ -21,7 +21,7 @@ type APIProxy struct {
 	enableBetaRestriction bool
 }
 
-// NewSingleHostReverseProxy is a function that creates a new httputil ReverseProxy and it transport
+// NewSingleHostReverseProxy is a function that creates a new httputil ReverseProxy, and its transport
 var NewSingleHostReverseProxy = func(target *url.URL, version, envHost, contextURL string) IReverseProxy {
 	pxy := httputil.NewSingleHostReverseProxy(target)
 	pxy.Transport = interceptor.NewRoundTripper(envHost+"/"+version, contextURL, http.DefaultTransport)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -238,13 +238,13 @@ func TestRouterPrivateAPIs(t *testing.T) {
 			"/instances": datasetAPIURL,
 		}
 		for _, version := range cfg.IdentityAPIVersions {
-			key := "/"+version+"/tokens"
+			key := "/" + version + "/tokens"
 			expectedPrivateURLs[key] = identityAPIURL
-			key = "/"+version+"/users"
+			key = "/" + version + "/users"
 			expectedPrivateURLs[key] = identityAPIURL
-			key = "/"+version+"/groups"
+			key = "/" + version + "/groups"
 			expectedPrivateURLs[key] = identityAPIURL
-			key = "/"+version+"/password-reset"
+			key = "/" + version + "/password-reset"
 			expectedPrivateURLs[key] = identityAPIURL
 		}
 
@@ -426,9 +426,9 @@ func TestRouterLegacyAPIs(t *testing.T) {
 }
 
 func assertOnlyThisURLIsCalled(expectedURL *url.URL) {
-	for url, pxy := range registeredProxies {
+	for urlToCheck, pxy := range registeredProxies {
 
-		if url == *expectedURL {
+		if urlToCheck == *expectedURL {
 			So(len(pxy.ServeHTTPCalls()), ShouldEqual, 1)
 			continue
 		}
@@ -454,8 +454,8 @@ func verifyProxied(path string, expectedURL *url.URL) {
 	So(len(pxy.ServeHTTPCalls()), ShouldEqual, 1)
 	So(pxy.ServeHTTPCalls()[0].Req.Header.Get(authorizationHeader), ShouldEqual, testServiceAuthToken)
 	So(pxy.ServeHTTPCalls()[0].Req.URL.Path, ShouldEqual, path)
-	for url, pxy := range registeredProxies {
-		if url != *expectedURL {
+	for urlToCheck, pxy := range registeredProxies {
+		if urlToCheck != *expectedURL {
 			So(len(pxy.ServeHTTPCalls()), ShouldEqual, 0)
 		}
 	}


### PR DESCRIPTION
### What

As per title

### How to review

Visual inspection.
Run tests ... with debugger, single stepping (add breakpoints) to observe that only files starting with { or [ are unmarshaled.

### Who can review

Anyone.
