### PR TITLE
Add route for /interactives - feature toggle protected

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,50 +8,53 @@ This service is responsible for serving a JSON-LD `@context` field on configured
 
 ## Configuration
 
-| Environment variable         | Default                                   | Description
-| ---------------------------- | ----------------------------------------- | -----------
-| ALLOWED_ORIGINS              | "http://localhost:8081"                   |
-| BIND_ADDR                    | ":23200"                                  | The host and port to bind to
-| ENV_HOST                     | "http://localhost:23200"                  | The public host for the environment the service is running on
-| VERSION                      | "v1"                                      | The version of the API
-| ENABLE_AUDIT                 | false                                     |
-| ENABLE_OBSERVATION_API       | false                                     |
-| ENABLE_PRIVATE_ENDPOINTS     | true                                      | If private endpoints should be routed
-| ENABLE_V1_BETA_RESTRICTION   | false                                     |
-| ENABLE_SESSIONS_API          | false                                     |
-| ENABLE_TOPIC_API             | false                                     |
-| ENABLE_ARTICLES_API          | false                                     | Flag to enable routing to the articles API
-| ENABLE_RELEASE_CALENDAR_API  | false                                     | Flag to enable routing to the release calendar API
-| ENABLE_ZEBEDEE_AUDIT         | false                                     |
-| CONTEXT_URL                  | ""                                        | A URL to the JSON-LD context file describing the APIs
-| API_POC_URL                  | "http://localhost:3000"                   | A URL to the poc api
-| ARTICLES_API_URL             | "http://localhost:27000"                  | A URL to the articles api
-| IMPORT_API_URL               | "http://localhost:21800"                  | A URL to the import api
-| DATASET_API_URL              | "http://localhost:22000"                  | A URL to the dataset api
-| FILTER_API_URL               | "http://localhost:22100"                  | A URL to the filter api
-| RECIPE_API_URL               | "http://localhost:22300"                  | A URL to the recipe api
-| CODE_LIST_API_URL            | "http://localhost:22400"                  | A URL to the code list api
-| HIERARCHY_API_URL            | "http://localhost:22600"                  | A URL to the hierarchy api
-| SEARCH_API_URL               | "http://localhost:23900"                  | A URL to the search api
-| DIMENSION_SEARCH_API_URL     | "http://localhost:23100"                  | A URL to the dimension search api
-| SESSIONS_API_URL             | "http://localhost:24400"                  | A URL to the sessions api
-| OBSERVATION_API_URL          | "http://localhost:24500"                  | A URL to the observation api
-| IMAGE_API_URL                | "http://localhost:24700"                  | A URL to the image api
-| UPLOAD_SERVICE_API_URL:      | "http://localhost:25100"                  | A URL to the upload service api
-| RELEASE_CALENDAR_API_URL     | "http://localhost:27800"                  | A URL to the release calendar api
-| ZEBEDEE_URL                  | "http://localhost:8082"                   | A URL to the zebedee service api
-| KAFKA_ADDR                   | localhost:9092                            | The list of kafka hosts
-| KAFKA_MAX_BYTES              | 2000000                                   | The maximum bytes that can be sent in an event to kafka topic
-| KAFKA_VERSION                | "1.0.2"                                   | The kafka version that this service expects to connect to
-| KAFKA_SEC_PROTO              | _unset_                    (only `TLS`)   | if set to `TLS`, kafka connections will use TLS
-| KAFKA_SEC_CLIENT_KEY         | _unset_                                   | PEM [2] for the client key (optional, used for client auth) [1]
-| KAFKA_SEC_CLIENT_CERT        | _unset_                                   | PEM [2] for the client certificate (optional, used for client auth) [1]
-| KAFKA_SEC_CA_CERTS           | _unset_                                   | PEM [2] of CA cert chain if using private CA for the server cert [1]
-| KAFKA_SEC_SKIP_VERIFY        | false                                     | ignore server certificate issues if set to `true` [1]
-| AUDIT_TOPIC                  | audit                                     | The kafka topic name for audit events
-| HEALTHCHECK_INTERVAL         | 30s                                       | The period of time between health checks
-| HEALTHCHECK_CRITICAL_TIMEOUT | 90s                                       | The period of time after which failing checks will result in critical global check
-| SHUTDOWN_TIMEOUT             | 5s                                        | The graceful shutdown timeout (`time.Duration` format)
+| Environment variable         | Default                                 | Description                                                                        |
+|------------------------------|-----------------------------------------|------------------------------------------------------------------------------------|
+| ALLOWED_ORIGINS              | "http://localhost:8081"                 |                                                                                    |
+| BIND_ADDR                    | ":23200"                                | The host and port to bind to                                                       |
+| ENV_HOST                     | "http://localhost:23200"                | The public host for the environment the service is running on                      |
+| VERSION                      | "v1"                                    | The version of the API                                                             |
+| ENABLE_AUDIT                 | false                                   |                                                                                    |
+| ENABLE_OBSERVATION_API       | false                                   |                                                                                    |
+| ENABLE_PRIVATE_ENDPOINTS     | true                                    | If private endpoints should be routed                                              |
+| ENABLE_V1_BETA_RESTRICTION   | false                                   |                                                                                    |
+| ENABLE_SESSIONS_API          | false                                   |                                                                                    |
+| ENABLE_TOPIC_API             | false                                   |                                                                                    |
+| ENABLE_ARTICLES_API          | false                                   | Flag to enable routing to the articles API                                         |
+| ENABLE_RELEASE_CALENDAR_API  | false                                   | Flag to enable routing to the release calendar API                                 |
+| ENABLE_INTERACTIVES_API      | false                                   | Flag to enable routing to the interactives API                                     |
+| ENABLE_ZEBEDEE_AUDIT         | false                                   |                                                                                    |
+| CONTEXT_URL                  | ""                                      | A URL to the JSON-LD context file describing the APIs                              |
+| API_POC_URL                  | "http://localhost:3000"                 | A URL to the poc api                                                               |
+| ARTICLES_API_URL             | "http://localhost:27000"                | A URL to the articles api                                                          |
+| IMPORT_API_URL               | "http://localhost:21800"                | A URL to the import api                                                            |
+| DATASET_API_URL              | "http://localhost:22000"                | A URL to the dataset api                                                           |
+| FILTER_API_URL               | "http://localhost:22100"                | A URL to the filter api                                                            |
+| RECIPE_API_URL               | "http://localhost:22300"                | A URL to the recipe api                                                            |
+| CODE_LIST_API_URL            | "http://localhost:22400"                | A URL to the code list api                                                         |
+| HIERARCHY_API_URL            | "http://localhost:22600"                | A URL to the hierarchy api                                                         |
+| SEARCH_API_URL               | "http://localhost:23900"                | A URL to the search api                                                            |
+| DIMENSION_SEARCH_API_URL     | "http://localhost:23100"                | A URL to the dimension search api                                                  |
+| SESSIONS_API_URL             | "http://localhost:24400"                | A URL to the sessions api                                                          |
+| OBSERVATION_API_URL          | "http://localhost:24500"                | A URL to the observation api                                                       |
+| IMAGE_API_URL                | "http://localhost:24700"                | A URL to the image api                                                             |
+| UPLOAD_SERVICE_API_URL:      | "http://localhost:25100"                | A URL to the upload service api                                                    |
+| RELEASE_CALENDAR_API_URL     | "http://localhost:27800"                | A URL to the release calendar api                                                  |
+| INTERACTIVES_API_URL         | "http://localhost:27500"                | A URL to the interactives api                                                      |
+| ZEBEDEE_URL                  | "http://localhost:8082"                 | A URL to the zebedee service api                                                   |
+| INTERACTIVES_API_VERSIONS    | "v1"                                    | A comma delimted string with a list of versions supported by interactives api      |
+| KAFKA_ADDR                   | localhost:9092                          | The list of kafka hosts                                                            |
+| KAFKA_MAX_BYTES              | 2000000                                 | The maximum bytes that can be sent in an event to kafka topic                      |
+| KAFKA_VERSION                | "1.0.2"                                 | The kafka version that this service expects to connect to                          |
+| KAFKA_SEC_PROTO              | _unset_                    (only `TLS`) | if set to `TLS`, kafka connections will use TLS                                    |
+| KAFKA_SEC_CLIENT_KEY         | _unset_                                 | PEM [2] for the client key (optional, used for client auth) [1]                    |
+| KAFKA_SEC_CLIENT_CERT        | _unset_                                 | PEM [2] for the client certificate (optional, used for client auth) [1]            |
+| KAFKA_SEC_CA_CERTS           | _unset_                                 | PEM [2] of CA cert chain if using private CA for the server cert [1]               |
+| KAFKA_SEC_SKIP_VERIFY        | false                                   | ignore server certificate issues if set to `true` [1]                              |
+| AUDIT_TOPIC                  | audit                                   | The kafka topic name for audit events                                              |
+| HEALTHCHECK_INTERVAL         | 30s                                     | The period of time between health checks                                           |
+| HEALTHCHECK_CRITICAL_TIMEOUT | 90s                                     | The period of time after which failing checks will result in critical global check |
+| SHUTDOWN_TIMEOUT             | 5s                                      | The graceful shutdown timeout (`time.Duration` format)                             |
 
 Notes:
 

--- a/config/config.go
+++ b/config/config.go
@@ -53,6 +53,9 @@ type Config struct {
 	ArticlesAPIURL             string        `envconfig:"ARTICLES_API_URL"`
 	EnableReleaseCalendarAPI   bool          `envconfig:"ENABLE_RELEASE_CALENDAR_API"`
 	ReleaseCalendarAPIURL      string        `envconfig:"RELEASE_CALENDAR_API_URL"`
+	EnableInteractivesAPI      bool          `envconfig:"ENABLE_INTERACTIVES_API"`
+	InteractivesAPIURL         string        `envconfig:"INTERACTIVES_API_URL"`
+	InteractivesAPIVersions    []string      `envconfig:"INTERACTIVES_API_VERSIONS"`
 }
 
 var cfg *Config
@@ -104,6 +107,9 @@ func Get() (*Config, error) {
 		EnableArticlesAPI:          false,
 		ReleaseCalendarAPIURL:      "http://localhost:27800",
 		EnableReleaseCalendarAPI:   false,
+		InteractivesAPIURL:         "http://localhost:27500",
+		EnableInteractivesAPI:      false,
+		InteractivesAPIVersions:    []string{"v1"},
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestGetRetrunsDefaultValues(t *testing.T) {
+func TestGetReturnsDefaultValues(t *testing.T) {
 	t.Parallel()
 	Convey("When a loading a configuration, default values are return", t, func() {
 		configuration, err := Get()
@@ -53,6 +53,9 @@ func TestGetRetrunsDefaultValues(t *testing.T) {
 			EnableArticlesAPI:          false,
 			ReleaseCalendarAPIURL:      "http://localhost:27800",
 			EnableReleaseCalendarAPI:   false,
+			InteractivesAPIURL:         "http://localhost:27500",
+			EnableInteractivesAPI:      false,
+			InteractivesAPIVersions:    []string{"v1"},
 		})
 	})
 }

--- a/service/service.go
+++ b/service/service.go
@@ -127,7 +127,7 @@ func (svc *Service) CreateMiddleware(cfg *config.Config, router *mux.Router) ali
 func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 	router := mux.NewRouter()
 
-	// Public APIs - by Feature Flag (ordering important)
+	// Public APIs
 	if cfg.EnableObservationAPI {
 		observation := proxy.NewAPIProxy(ctx, cfg.ObservationAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
 		addTransitionalHandler(router, observation, "/datasets/{dataset_id}/editions/{edition}/versions/{version}/observations")
@@ -136,10 +136,13 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		topic := proxy.NewAPIProxy(ctx, cfg.TopicAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
 		addTransitionalHandler(router, topic, "/topics")
 	}
-	if cfg.EnableInteractivesAPI {
-		interactives := proxy.NewAPIProxy(ctx, cfg.InteractivesAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
-		addVersionedHandlers(router, interactives, cfg.InteractivesAPIVersions, "/interactives")
-	}
+	codeList := proxy.NewAPIProxy(ctx, cfg.CodelistAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	dataset := proxy.NewAPIProxy(ctx, cfg.DatasetAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
+	filter := proxy.NewAPIProxy(ctx, cfg.FilterAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	hierarchy := proxy.NewAPIProxy(ctx, cfg.HierarchyAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	search := proxy.NewAPIProxy(ctx, cfg.SearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	dimensionSearch := proxy.NewAPIProxy(ctx, cfg.DimensionSearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	image := proxy.NewAPIProxy(ctx, cfg.ImageAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	if cfg.EnableArticlesAPI {
 		articles := proxy.NewAPIProxy(ctx, cfg.ArticlesAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		addTransitionalHandler(router, articles, "/articles")
@@ -148,18 +151,6 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		releaseCalendar := proxy.NewAPIProxy(ctx, cfg.ReleaseCalendarAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		addTransitionalHandler(router, releaseCalendar, "/releasecalendar")
 	}
-	if cfg.EnablePopulationTypesAPI {
-		populationTypesAPI := proxy.NewAPIProxy(ctx, cfg.PopulationTypesAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-		addTransitionalHandler(router, populationTypesAPI, "/population-types")
-	}
-	// Public APIs - default
-	codeList := proxy.NewAPIProxy(ctx, cfg.CodelistAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-	dataset := proxy.NewAPIProxy(ctx, cfg.DatasetAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
-	filter := proxy.NewAPIProxy(ctx, cfg.FilterAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-	hierarchy := proxy.NewAPIProxy(ctx, cfg.HierarchyAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-	search := proxy.NewAPIProxy(ctx, cfg.SearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-	dimensionSearch := proxy.NewAPIProxy(ctx, cfg.DimensionSearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-	image := proxy.NewAPIProxy(ctx, cfg.ImageAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	addTransitionalHandler(router, codeList, "/code-lists")
 	addTransitionalHandler(router, dataset, "/datasets")
 	addTransitionalHandler(router, filter, "/filters")
@@ -168,6 +159,15 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 	addTransitionalHandler(router, search, "/search")
 	addTransitionalHandler(router, dimensionSearch, "/dimension-search")
 	addTransitionalHandler(router, image, "/images")
+
+	if cfg.EnablePopulationTypesAPI {
+		populationTypesAPI := proxy.NewAPIProxy(ctx, cfg.PopulationTypesAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+		addTransitionalHandler(router, populationTypesAPI, "/population-types")
+	}
+	if cfg.EnableInteractivesAPI {
+		interactives := proxy.NewAPIProxy(ctx, cfg.InteractivesAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
+		addVersionedHandlers(router, interactives, cfg.InteractivesAPIVersions, "/interactives")
+	}
 
 	// Private APIs
 	if cfg.EnablePrivateEndpoints {

--- a/service/service.go
+++ b/service/service.go
@@ -127,23 +127,7 @@ func (svc *Service) CreateMiddleware(cfg *config.Config, router *mux.Router) ali
 func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 	router := mux.NewRouter()
 
-	// Public APIs
-	codeList := proxy.NewAPIProxy(ctx, cfg.CodelistAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-	dataset := proxy.NewAPIProxy(ctx, cfg.DatasetAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
-	filter := proxy.NewAPIProxy(ctx, cfg.FilterAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-	hierarchy := proxy.NewAPIProxy(ctx, cfg.HierarchyAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-	search := proxy.NewAPIProxy(ctx, cfg.SearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-	dimensionSearch := proxy.NewAPIProxy(ctx, cfg.DimensionSearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-	image := proxy.NewAPIProxy(ctx, cfg.ImageAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-	addTransitionalHandler(router, codeList, "/code-lists")
-	addTransitionalHandler(router, dataset, "/datasets")
-	addTransitionalHandler(router, filter, "/filters")
-	addTransitionalHandler(router, filter, "/filter-outputs")
-	addTransitionalHandler(router, hierarchy, "/hierarchies")
-	addTransitionalHandler(router, search, "/search")
-	addTransitionalHandler(router, dimensionSearch, "/dimension-search")
-	addTransitionalHandler(router, image, "/images")
-	// By Feature Flag
+	// Public APIs - by Feature Flag (ordering important)
 	if cfg.EnableObservationAPI {
 		observation := proxy.NewAPIProxy(ctx, cfg.ObservationAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
 		addTransitionalHandler(router, observation, "/datasets/{dataset_id}/editions/{edition}/versions/{version}/observations")
@@ -168,6 +152,22 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		populationTypesAPI := proxy.NewAPIProxy(ctx, cfg.PopulationTypesAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		addTransitionalHandler(router, populationTypesAPI, "/population-types")
 	}
+	// Public APIs - default
+	codeList := proxy.NewAPIProxy(ctx, cfg.CodelistAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	dataset := proxy.NewAPIProxy(ctx, cfg.DatasetAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
+	filter := proxy.NewAPIProxy(ctx, cfg.FilterAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	hierarchy := proxy.NewAPIProxy(ctx, cfg.HierarchyAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	search := proxy.NewAPIProxy(ctx, cfg.SearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	dimensionSearch := proxy.NewAPIProxy(ctx, cfg.DimensionSearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	image := proxy.NewAPIProxy(ctx, cfg.ImageAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	addTransitionalHandler(router, codeList, "/code-lists")
+	addTransitionalHandler(router, dataset, "/datasets")
+	addTransitionalHandler(router, filter, "/filters")
+	addTransitionalHandler(router, filter, "/filter-outputs")
+	addTransitionalHandler(router, hierarchy, "/hierarchies")
+	addTransitionalHandler(router, search, "/search")
+	addTransitionalHandler(router, dimensionSearch, "/dimension-search")
+	addTransitionalHandler(router, image, "/images")
 
 	// Private APIs
 	if cfg.EnablePrivateEndpoints {

--- a/service/service.go
+++ b/service/service.go
@@ -123,10 +123,27 @@ func (svc *Service) CreateMiddleware(cfg *config.Config, router *mux.Router) ali
 }
 
 // CreateRouter creates the router with the required endpoints for proxied APIs
+// The preferred approach for new APIs is to use `addVersionedHandlers` and include the version on downstream API routes
 func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 	router := mux.NewRouter()
 
 	// Public APIs
+	codeList := proxy.NewAPIProxy(ctx, cfg.CodelistAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	dataset := proxy.NewAPIProxy(ctx, cfg.DatasetAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
+	filter := proxy.NewAPIProxy(ctx, cfg.FilterAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	hierarchy := proxy.NewAPIProxy(ctx, cfg.HierarchyAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	search := proxy.NewAPIProxy(ctx, cfg.SearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	dimensionSearch := proxy.NewAPIProxy(ctx, cfg.DimensionSearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	image := proxy.NewAPIProxy(ctx, cfg.ImageAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	addTransitionalHandler(router, codeList, "/code-lists")
+	addTransitionalHandler(router, dataset, "/datasets")
+	addTransitionalHandler(router, filter, "/filters")
+	addTransitionalHandler(router, filter, "/filter-outputs")
+	addTransitionalHandler(router, hierarchy, "/hierarchies")
+	addTransitionalHandler(router, search, "/search")
+	addTransitionalHandler(router, dimensionSearch, "/dimension-search")
+	addTransitionalHandler(router, image, "/images")
+	// By Feature Flag
 	if cfg.EnableObservationAPI {
 		observation := proxy.NewAPIProxy(ctx, cfg.ObservationAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
 		addTransitionalHandler(router, observation, "/datasets/{dataset_id}/editions/{edition}/versions/{version}/observations")
@@ -139,13 +156,6 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		interactives := proxy.NewAPIProxy(ctx, cfg.InteractivesAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
 		addVersionedHandlers(router, interactives, cfg.InteractivesAPIVersions, "/interactives")
 	}
-	codeList := proxy.NewAPIProxy(ctx, cfg.CodelistAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-	dataset := proxy.NewAPIProxy(ctx, cfg.DatasetAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
-	filter := proxy.NewAPIProxy(ctx, cfg.FilterAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-	hierarchy := proxy.NewAPIProxy(ctx, cfg.HierarchyAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-	search := proxy.NewAPIProxy(ctx, cfg.SearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-	dimensionSearch := proxy.NewAPIProxy(ctx, cfg.DimensionSearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-	image := proxy.NewAPIProxy(ctx, cfg.ImageAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	if cfg.EnableArticlesAPI {
 		articles := proxy.NewAPIProxy(ctx, cfg.ArticlesAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		addTransitionalHandler(router, articles, "/articles")
@@ -154,19 +164,11 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		releaseCalendar := proxy.NewAPIProxy(ctx, cfg.ReleaseCalendarAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		addTransitionalHandler(router, releaseCalendar, "/releasecalendar")
 	}
-	addTransitionalHandler(router, codeList, "/code-lists")
-	addTransitionalHandler(router, dataset, "/datasets")
-	addTransitionalHandler(router, filter, "/filters")
-	addTransitionalHandler(router, filter, "/filter-outputs")
-	addTransitionalHandler(router, hierarchy, "/hierarchies")
-	addTransitionalHandler(router, search, "/search")
-	addTransitionalHandler(router, dimensionSearch, "/dimension-search")
-	addTransitionalHandler(router, image, "/images")
-
 	if cfg.EnablePopulationTypesAPI {
 		populationTypesAPI := proxy.NewAPIProxy(ctx, cfg.PopulationTypesAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		addTransitionalHandler(router, populationTypesAPI, "/population-types")
 	}
+
 	// Private APIs
 	if cfg.EnablePrivateEndpoints {
 		recipe := proxy.NewAPIProxy(ctx, cfg.RecipeAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)

--- a/service/service.go
+++ b/service/service.go
@@ -135,6 +135,10 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		topic := proxy.NewAPIProxy(ctx, cfg.TopicAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
 		addTransitionalHandler(router, topic, "/topics")
 	}
+	if cfg.EnableInteractivesAPI {
+		interactives := proxy.NewAPIProxy(ctx, cfg.InteractivesAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
+		addVersionedHandlers(router, interactives, cfg.InteractivesAPIVersions, "/interactives")
+	}
 	codeList := proxy.NewAPIProxy(ctx, cfg.CodelistAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	dataset := proxy.NewAPIProxy(ctx, cfg.DatasetAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
 	filter := proxy.NewAPIProxy(ctx, cfg.FilterAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)


### PR DESCRIPTION
### What

Adding an `/interactives` route, pointing to a new API (coming soon) for managing interactives (e.g. the iframe here: https://www.ons.gov.uk/businessindustryandtrade/internationaltrade/articles/internationalimportsofservicestosubnationalareasoftheuk/2017#service-imports-into-the-english-regions-and-three-devolved-nations).

Notes:

Behind a feature toggle: off by default

### How to review

Its v basic - check code & tests pass enough I think

### Who can review

Anyone
