### PR TITLE
Add population-types resource endpoint to api router

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -51,6 +51,8 @@ type Config struct {
 	EnableTopicAPI             bool          `envconfig:"ENABLE_TOPIC_API"`
 	EnableArticlesAPI          bool          `envconfig:"ENABLE_ARTICLES_API"`
 	ArticlesAPIURL             string        `envconfig:"ARTICLES_API_URL"`
+	PopulationTypesAPIURL      string        `envconfig:"POPULATION_TYPES_API_URL"`
+	EnablePopulationTypesAPI   bool          `envconfig:"ENABLE_POPULATION_TYPES_API"`
 	EnableReleaseCalendarAPI   bool          `envconfig:"ENABLE_RELEASE_CALENDAR_API"`
 	ReleaseCalendarAPIURL      string        `envconfig:"RELEASE_CALENDAR_API_URL"`
 }
@@ -102,6 +104,8 @@ func Get() (*Config, error) {
 		EnableTopicAPI:             false,
 		ArticlesAPIURL:             "http://localhost:27000",
 		EnableArticlesAPI:          false,
+		PopulationTypesAPIURL:      "http://localhost:27300",
+		EnablePopulationTypesAPI:   false,
 		ReleaseCalendarAPIURL:      "http://localhost:27800",
 		EnableReleaseCalendarAPI:   false,
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -59,11 +59,6 @@ type Config struct {
 
 var cfg *Config
 
-// Flush is a testing seam to allow reset to pre-initialised configuration
-func Flush() {
-	cfg = nil
-}
-
 // Get configures the application and returns the configuration
 func Get() (*Config, error) {
 	if cfg != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -59,6 +59,11 @@ type Config struct {
 
 var cfg *Config
 
+// Flush is a testing seam to allow reset to pre-initialised configuration
+func Flush() {
+	cfg = nil
+}
+
 // Get configures the application and returns the configuration
 func Get() (*Config, error) {
 	if cfg != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"github.com/hashicorp/go-uuid"
-	"os"
 	"testing"
 	"time"
 
@@ -59,50 +57,4 @@ func TestGetRetrunsDefaultValues(t *testing.T) {
 			EnableReleaseCalendarAPI:   false,
 		})
 	})
-}
-
-func TestEnvironmentVariableBinding(t *testing.T) {
-
-	Convey("PopulationTypesAPIURL should be bound to POPULATION_TYPES_API_URL", t, func() {
-		expectedValue, _ := uuid.GenerateUUID()
-		undo := setEnvVar("POPULATION_TYPES_API_URL", expectedValue)
-		defer undo()
-		configuration, err := Get()
-		So(err, ShouldBeNil)
-		So(configuration.PopulationTypesAPIURL, ShouldEqual, expectedValue)
-	})
-
-	Convey("EnablePopulationTypesAPI should be bound to ENABLE_POPULATION_TYPES_API", t, func() {
-		undo := setEnvVar("ENABLE_POPULATION_TYPES_API", "true")
-		defer undo()
-		configuration, err := Get()
-		So(err, ShouldBeNil)
-		So(configuration.EnablePopulationTypesAPI, ShouldBeTrue)
-	})
-}
-
-func setEnvVar(name string, value string) func() {
-	existingValue, isValueSet := os.LookupEnv(name)
-	setenvOrPanic(name, value)
-	return func() {
-		if isValueSet {
-			setenvOrPanic(name, existingValue)
-		} else {
-			unsetenvOrPanic(name)
-		}
-		// remove the cached configuration so that it can be re-read on next Get
-		Flush()
-	}
-}
-
-func unsetenvOrPanic(name string) {
-	if err := os.Unsetenv(name); err != nil {
-		panic(err)
-	}
-}
-
-func setenvOrPanic(name string, value string) {
-	if err := os.Setenv(name, value); err != nil {
-		panic(err)
-	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -51,6 +51,8 @@ func TestGetRetrunsDefaultValues(t *testing.T) {
 			EnableTopicAPI:             false,
 			ArticlesAPIURL:             "http://localhost:27000",
 			EnableArticlesAPI:          false,
+			PopulationTypesAPIURL:      "http://localhost:27300",
+			EnablePopulationTypesAPI:   false,
 			ReleaseCalendarAPIURL:      "http://localhost:27800",
 			EnableReleaseCalendarAPI:   false,
 		})

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"github.com/hashicorp/go-uuid"
+	"os"
 	"testing"
 	"time"
 
@@ -56,5 +58,23 @@ func TestGetRetrunsDefaultValues(t *testing.T) {
 			ReleaseCalendarAPIURL:      "http://localhost:27800",
 			EnableReleaseCalendarAPI:   false,
 		})
+	})
+}
+
+func TestEnvironmentVariableBinding(t *testing.T) {
+
+	Convey("PopulationTypesAPIURL should be bound to POPULATION_TYPES_API_URL", t, func() {
+		expectedValue, _ := uuid.GenerateUUID()
+		os.Setenv("POPULATION_TYPES_API_URL", expectedValue)
+		Flush()
+		configuration, _ := Get()
+		So(configuration.PopulationTypesAPIURL, ShouldEqual, expectedValue)
+	})
+
+	Convey("EnablePopulationTypesAPI should be bound to ENABLE_POPULATION_TYPES_API", t, func() {
+		os.Setenv("ENABLE_POPULATION_TYPES_API", "true")
+		Flush()
+		configuration, _ := Get()
+		So(configuration.EnablePopulationTypesAPI, ShouldBeTrue)
 	})
 }

--- a/service/service.go
+++ b/service/service.go
@@ -159,6 +159,10 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 	addTransitionalHandler(router, dimensionSearch, "/dimension-search")
 	addTransitionalHandler(router, image, "/images")
 
+	if cfg.EnablePopulationTypesAPI {
+		populationTypesAPI := proxy.NewAPIProxy(ctx, cfg.PopulationTypesAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+		addTransitionalHandler(router, populationTypesAPI, "/population-types")
+	}
 	// Private APIs
 	if cfg.EnablePrivateEndpoints {
 		recipe := proxy.NewAPIProxy(ctx, cfg.RecipeAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -76,6 +76,8 @@ func TestRouterPublicAPIs(t *testing.T) {
 		So(err, ShouldBeNil)
 		releaseCalendarAPIURL, err := url.Parse(cfg.ReleaseCalendarAPIURL)
 		So(err, ShouldBeNil)
+		populationTypesAPIURL, err := url.Parse(cfg.PopulationTypesAPIURL)
+		So(err, ShouldBeNil)
 
 		expectedPublicURLs := map[string]*url.URL{
 			"/code-lists": codelistAPIURL,
@@ -89,6 +91,7 @@ func TestRouterPublicAPIs(t *testing.T) {
 			"/images":           imageAPIURL,
 			"/articles":         articlesAPIURL,
 			"/releasecalendar":  releaseCalendarAPIURL,
+			"/population-types": populationTypesAPIURL,
 		}
 
 		resetProxyMocksWithExpectations(expectedPublicURLs)
@@ -268,6 +271,31 @@ func TestRouterPublicAPIs(t *testing.T) {
 				})
 			})
 		})
+
+		Convey("Given the population types API is enabled", func() {
+			cfg.EnablePopulationTypesAPI = true
+			Convey("When population types is requested", func() {
+				url := "http://localhost:23200/v1/population-types"
+				w := createRouterTest(cfg, url)
+				Convey("Then the population types API should respond to the request", func() {
+					So(w.Code, ShouldEqual, http.StatusOK)
+					verifyProxied("/population-types", populationTypesAPIURL)
+				})
+			})
+		})
+
+		Convey("Given the population types API is NOT enabled", func() {
+			cfg.EnablePopulationTypesAPI = false
+			Convey("When population types is requested", func() {
+				url := "http://localhost:23200/v1/population-types"
+				w := createRouterTest(cfg, url)
+				Convey("Then the default zebedee handler should respond", func() {
+					So(w.Code, ShouldEqual, http.StatusOK)
+					verifyProxied("/population-types", zebedeeURL)
+				})
+			})
+		})
+
 	})
 }
 


### PR DESCRIPTION
### What

Added endpoint routing and configuration for population-types API
Added a test seam allowing reset of configuration to `nil` so that unit tests can verify environment variable binding (Config.go: `Flush()`)

### How to review

Read. Evaluate.

### Who can review

Gophers