### PR TITLE
Add dp-cantabular-dimension-api to router

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,55 +8,56 @@ This service is responsible for serving a JSON-LD `@context` field on configured
 
 ## Configuration
 
-| Environment variable         | Default                                 | Description                                                                        |
-|------------------------------|-----------------------------------------|------------------------------------------------------------------------------------|
-| ALLOWED_ORIGINS              | "http://localhost:8081"                 |                                                                                    |
-| BIND_ADDR                    | ":23200"                                | The host and port to bind to                                                       |
-| ENV_HOST                     | "http://localhost:23200"                | The public host for the environment the service is running on                      |
-| VERSION                      | "v1"                                    | The version of the API                                                             |
-| ENABLE_AUDIT                 | false                                   |                                                                                    |
-| ENABLE_OBSERVATION_API       | false                                   |                                                                                    |
-| ENABLE_PRIVATE_ENDPOINTS     | true                                    | If private endpoints should be routed                                              |
-| ENABLE_V1_BETA_RESTRICTION   | false                                   |                                                                                    |
-| ENABLE_SESSIONS_API          | false                                   |                                                                                    |
-| ENABLE_TOPIC_API             | false                                   |                                                                                    |
-| ENABLE_ARTICLES_API          | false                                   | Flag to enable routing to the articles API                                         |
-| ENABLE_RELEASE_CALENDAR_API  | false                                   | Flag to enable routing to the release calendar API                                 |
-| ENABLE_INTERACTIVES_API      | false                                   | Flag to enable routing to the interactives API                                     |
-| ENABLE_ZEBEDEE_AUDIT         | false                                   |                                                                                    |
-| CONTEXT_URL                  | ""                                      | A URL to the JSON-LD context file describing the APIs                              |
-| API_POC_URL                  | "http://localhost:3000"                 | A URL to the poc api                                                               |
-| ARTICLES_API_URL             | "http://localhost:27000"                | A URL to the articles api                                                          |
-| IMPORT_API_URL               | "http://localhost:21800"                | A URL to the import api                                                            |
-| DATASET_API_URL              | "http://localhost:22000"                | A URL to the dataset api                                                           |
-| FILTER_API_URL               | "http://localhost:22100"                | A URL to the filter api                                                            |
-| RECIPE_API_URL               | "http://localhost:22300"                | A URL to the recipe api                                                            |
-| CODE_LIST_API_URL            | "http://localhost:22400"                | A URL to the code list api                                                         |
-| HIERARCHY_API_URL            | "http://localhost:22600"                | A URL to the hierarchy api                                                         |
-| SEARCH_API_URL               | "http://localhost:23900"                | A URL to the search api                                                            |
-| DIMENSION_SEARCH_API_URL     | "http://localhost:23100"                | A URL to the dimension search api                                                  |
-| SESSIONS_API_URL             | "http://localhost:24400"                | A URL to the sessions api                                                          |
-| OBSERVATION_API_URL          | "http://localhost:24500"                | A URL to the observation api                                                       |
-| IMAGE_API_URL                | "http://localhost:24700"                | A URL to the image api                                                             |
-| UPLOAD_SERVICE_API_URL:      | "http://localhost:25100"                | A URL to the upload service api                                                    |
-| IDENTITY_API_URL:            | "http://localhost:25600"                | A URL to the identity api                                                          |
-| IDENTITY_API_VERSIONS        | "v1"                                    | A comma delimted string with a list of versions supported by identity api          |
-| RELEASE_CALENDAR_API_URL     | "http://localhost:27800"                | A URL to the release calendar api                                                  |
-| INTERACTIVES_API_URL         | "http://localhost:27500"                | A URL to the interactives api                                                      |
-| ZEBEDEE_URL                  | "http://localhost:8082"                 | A URL to the zebedee service api                                                   |
-| INTERACTIVES_API_VERSIONS    | "v1"                                    | A comma delimted string with a list of versions supported by interactives api      |
-| KAFKA_ADDR                   | localhost:9092                          | The list of kafka hosts                                                            |
-| KAFKA_MAX_BYTES              | 2000000                                 | The maximum bytes that can be sent in an event to kafka topic                      |
-| KAFKA_VERSION                | "1.0.2"                                 | The kafka version that this service expects to connect to                          |
+| Environment variable         | Default                               | Description                                                                        |
+|------------------------------|---------------------------------------|------------------------------------------------------------------------------------|
+| ALLOWED_ORIGINS              | "http://localhost:8081"               |                                                                                    |
+| BIND_ADDR                    | ":23200"                              | The host and port to bind to                                                       |
+| ENV_HOST                     | "http://localhost:23200"              | The public host for the environment the service is running on                      |
+| VERSION                      | "v1"                                  | The version of the API                                                             |
+| ENABLE_AUDIT                 | false                                 |                                                                                    |
+| ENABLE_OBSERVATION_API       | false                                 |                                                                                    |
+| ENABLE_PRIVATE_ENDPOINTS     | true                                  | If private endpoints should be routed                                              |
+| ENABLE_V1_BETA_RESTRICTION   | false                                 |                                                                                    |
+| ENABLE_SESSIONS_API          | false                                 |                                                                                    |
+| ENABLE_TOPIC_API             | false                                 |                                                                                    |
+| ENABLE_ARTICLES_API          | false                                 | Flag to enable routing to the articles API                                         |
+| ENABLE_RELEASE_CALENDAR_API  | false                                 | Flag to enable routing to the release calendar API                                 |
+| ENABLE_INTERACTIVES_API      | false                                 | Flag to enable routing to the interactives API                                     |
+| ENABLE_ZEBEDEE_AUDIT         | false                                 |                                                                                    |
+| CONTEXT_URL                  | ""                                    | A URL to the JSON-LD context file describing the APIs                              |
+| API_POC_URL                  | "http://localhost:3000"               | A URL to the poc api                                                               |
+| ARTICLES_API_URL             | "http://localhost:27000"              | A URL to the articles api                                                          |
+| IMPORT_API_URL               | "http://localhost:21800"              | A URL to the import api                                                            |
+| DATASET_API_URL              | "http://localhost:22000"              | A URL to the dataset api                                                           |
+| FILTER_API_URL               | "http://localhost:22100"              | A URL to the filter api                                                            |
+| RECIPE_API_URL               | "http://localhost:22300"              | A URL to the recipe api                                                            |
+| CODE_LIST_API_URL            | "http://localhost:22400"              | A URL to the code list api                                                         |
+| HIERARCHY_API_URL            | "http://localhost:22600"              | A URL to the hierarchy api                                                         |
+| SEARCH_API_URL               | "http://localhost:23900"              | A URL to the search api                                                            |
+| DIMENSION_SEARCH_API_URL     | "http://localhost:23100"              | A URL to the dimension search api                                                  |
+| SESSIONS_API_URL             | "http://localhost:24400"              | A URL to the sessions api                                                          |
+| OBSERVATION_API_URL          | "http://localhost:24500"              | A URL to the observation api                                                       |
+| IMAGE_API_URL                | "http://localhost:24700"              | A URL to the image api                                                             |
+| UPLOAD_SERVICE_API_URL:      | "http://localhost:25100"              | A URL to the upload service api                                                    |
+| IDENTITY_API_URL:            | "http://localhost:25600"              | A URL to the identity api                                                          |
+| IDENTITY_API_VERSIONS        | "v1"                                  | A comma delimted string with a list of versions supported by identity api          |
+| RELEASE_CALENDAR_API_URL     | "http://localhost:27800"              | A URL to the release calendar api                                                  |
+| INTERACTIVES_API_URL         | "http://localhost:27500"              | A URL to the interactives api                                                      |
+| ZEBEDEE_URL                  | "http://localhost:8082"               | A URL to the zebedee service api                                                   |
+| INTERACTIVES_API_VERSIONS    | "v1"                                  | A comma delimted string with a list of versions supported by interactives api      |
+| DIMENSIONS_API_URL           | "http://localhost:27200"              | A URL to the dimensions api                                                        |
+| KAFKA_ADDR                   | localhost:9092                        | The list of kafka hosts                                                            |
+| KAFKA_MAX_BYTES              | 2000000                               | The maximum bytes that can be sent in an event to kafka topic                      |
+| KAFKA_VERSION                | "1.0.2"                               | The kafka version that this service expects to connect to                          |
 | KAFKA_SEC_PROTO              | _unset_                    (only `TLS`) | if set to `TLS`, kafka connections will use TLS                                    |
-| KAFKA_SEC_CLIENT_KEY         | _unset_                                 | PEM [2] for the client key (optional, used for client auth) [1]                    |
-| KAFKA_SEC_CLIENT_CERT        | _unset_                                 | PEM [2] for the client certificate (optional, used for client auth) [1]            |
-| KAFKA_SEC_CA_CERTS           | _unset_                                 | PEM [2] of CA cert chain if using private CA for the server cert [1]               |
-| KAFKA_SEC_SKIP_VERIFY        | false                                   | ignore server certificate issues if set to `true` [1]                              |
-| AUDIT_TOPIC                  | audit                                   | The kafka topic name for audit events                                              |
-| HEALTHCHECK_INTERVAL         | 30s                                     | The period of time between health checks                                           |
-| HEALTHCHECK_CRITICAL_TIMEOUT | 90s                                     | The period of time after which failing checks will result in critical global check |
-| SHUTDOWN_TIMEOUT             | 5s                                      | The graceful shutdown timeout (`time.Duration` format)                             |
+| KAFKA_SEC_CLIENT_KEY         | _unset_                               | PEM [2] for the client key (optional, used for client auth) [1]                    |
+| KAFKA_SEC_CLIENT_CERT        | _unset_                               | PEM [2] for the client certificate (optional, used for client auth) [1]            |
+| KAFKA_SEC_CA_CERTS           | _unset_                               | PEM [2] of CA cert chain if using private CA for the server cert [1]               |
+| KAFKA_SEC_SKIP_VERIFY        | false                                 | ignore server certificate issues if set to `true` [1]                              |
+| AUDIT_TOPIC                  | audit                                 | The kafka topic name for audit events                                              |
+| HEALTHCHECK_INTERVAL         | 30s                                   | The period of time between health checks                                           |
+| HEALTHCHECK_CRITICAL_TIMEOUT | 90s                                   | The period of time after which failing checks will result in critical global check |
+| SHUTDOWN_TIMEOUT             | 5s                                    | The graceful shutdown timeout (`time.Duration` format)                             |
 
 Notes:
 

--- a/config/config.go
+++ b/config/config.go
@@ -60,6 +60,7 @@ type Config struct {
 	EnableInteractivesAPI      bool          `envconfig:"ENABLE_INTERACTIVES_API"`
 	InteractivesAPIURL         string        `envconfig:"INTERACTIVES_API_URL"`
 	InteractivesAPIVersions    []string      `envconfig:"INTERACTIVES_API_VERSIONS"`
+	DimensionsAPIURL           string        `envconfig:"DIMENSIONS_API_URL"`
 }
 
 var cfg *Config
@@ -118,6 +119,7 @@ func Get() (*Config, error) {
 		InteractivesAPIURL:         "http://localhost:27500",
 		EnableInteractivesAPI:      false,
 		InteractivesAPIVersions:    []string{"v1"},
+		DimensionsAPIURL:           "http://localhost:27200",
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -60,6 +60,7 @@ func TestGetReturnsDefaultValues(t *testing.T) {
 			InteractivesAPIURL:         "http://localhost:27500",
 			EnableInteractivesAPI:      false,
 			InteractivesAPIVersions:    []string{"v1"},
+			DimensionsAPIURL:           "http://localhost:27200",
 		})
 	})
 }

--- a/service/service.go
+++ b/service/service.go
@@ -142,6 +142,7 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 	hierarchy := proxy.NewAPIProxy(ctx, cfg.HierarchyAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	search := proxy.NewAPIProxy(ctx, cfg.SearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	dimensionSearch := proxy.NewAPIProxy(ctx, cfg.DimensionSearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	dimensions := proxy.NewAPIProxy(ctx, cfg.DimensionsAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
 	image := proxy.NewAPIProxy(ctx, cfg.ImageAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	if cfg.EnableArticlesAPI {
 		articles := proxy.NewAPIProxy(ctx, cfg.ArticlesAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
@@ -159,6 +160,7 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 	addTransitionalHandler(router, search, "/search")
 	addTransitionalHandler(router, dimensionSearch, "/dimension-search")
 	addTransitionalHandler(router, image, "/images")
+	addTransitionalHandler(router, dimensions, "/area-types")
 
 	if cfg.EnablePopulationTypesAPI {
 		populationTypesAPI := proxy.NewAPIProxy(ctx, cfg.PopulationTypesAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -81,6 +81,8 @@ func TestRouterPublicAPIs(t *testing.T) {
 		So(err, ShouldBeNil)
 		interactivesAPIURL, err := url.Parse(cfg.InteractivesAPIURL)
 		So(err, ShouldBeNil)
+		dimensionsAPIURL, err := url.Parse(cfg.DimensionsAPIURL)
+		So(err, ShouldBeNil)
 
 		expectedPublicURLs := map[string]*url.URL{
 			"/code-lists": codelistAPIURL,
@@ -93,6 +95,7 @@ func TestRouterPublicAPIs(t *testing.T) {
 			"/dimension-search": dimensionSearchAPIURL,
 			"/images":           imageAPIURL,
 			"/population-types": populationTypesAPIURL,
+			"/area-types":       dimensionsAPIURL,
 		}
 		cfg.ArticlesAPIVersions = []string{"a", "b"}
 		for _, version := range cfg.ArticlesAPIVersions {
@@ -384,6 +387,12 @@ func TestRouterPublicAPIs(t *testing.T) {
 					}
 				})
 			})
+		})
+
+		Convey("A request to the dimensions area-types endpoint is proxied to dimensionsAPIURL", func() {
+			w := createRouterTest(cfg, "http://localhost:23200/v1/area-types")
+			So(w.Code, ShouldEqual, http.StatusOK)
+			verifyProxied("/area-types", dimensionsAPIURL)
 		})
 	})
 }


### PR DESCRIPTION
Adds the Dimension API's `/area-types` endpoint to the public router.

Resolves: 5569 (partial) https://trello.com/c/yOjZDYAj

### What

Describe what you have changed and why.

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
