### PR TITLE
add dp-geodata-api (private, versioned) to /geodata route

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ This service is responsible for serving a JSON-LD `@context` field on configured
 | SESSIONS_API_URL             | "http://localhost:24400"              | A URL to the sessions api                                                          |
 | OBSERVATION_API_URL          | "http://localhost:24500"              | A URL to the observation api                                                       |
 | IMAGE_API_URL                | "http://localhost:24700"              | A URL to the image api                                                             |
-| UPLOAD_SERVICE_API_URL:      | "http://localhost:25100"              | A URL to the upload service api
-| FILES_API_URL:      | "http://localhost:26900"              | A URL to the files API                                                                             |
-| DOWNLOAD_SERVICE_URL:      | "http://localhost:23600"              | A URL to the download service API                                                                             |
+| UPLOAD_SERVICE_API_URL:      | "http://localhost:25100"              | A URL to the upload service api                                                    |
+| FILES_API_URL:               | "http://localhost:26900"              | A URL to the files API                                                             |
+| DOWNLOAD_SERVICE_URL:        | "http://localhost:23600"              | A URL to the download service API                                                  |
 | IDENTITY_API_URL:            | "http://localhost:25600"              | A URL to the identity api                                                          |
 | IDENTITY_API_VERSIONS        | "v1"                                  | A comma delimted string with a list of versions supported by identity api          |
 | PERMISSIONS_API_URL:         | "http://localhost:25400"              | A URL to the permissions api                                                       |
@@ -53,10 +53,12 @@ This service is responsible for serving a JSON-LD `@context` field on configured
 | DIMENSIONS_API_URL           | "http://localhost:27200"              | A URL to the dimensions api                                                        |
 | MAPS_API_URL:                | "http://localhost:27900"              | A URL to the maps api                                                              |
 | MAPS_API_VERSIONS:           | "v1"                                  | A comma delimted string with a list of versions supported by maps api              |
+| GEODATA_API_URL              | "http://localhost:28200"              | A URL to the geodata api                                                           |
+| GEODATA_API_VERSIONS         | "v1"                                  | A comma delimted string with a list of versions supported by geodata api           |
 | KAFKA_ADDR                   | localhost:9092                        | The list of kafka hosts                                                            |
 | KAFKA_MAX_BYTES              | 2000000                               | The maximum bytes that can be sent in an event to kafka topic                      |
 | KAFKA_VERSION                | "1.0.2"                               | The kafka version that this service expects to connect to                          |
-| KAFKA_SEC_PROTO              | _unset_                    (only `TLS`) | if set to `TLS`, kafka connections will use TLS                                  |
+| KAFKA_SEC_PROTO              | _unset_                  (only `TLS`) | if set to `TLS`, kafka connections will use TLS                                    |
 | KAFKA_SEC_CLIENT_KEY         | _unset_                               | PEM [2] for the client key (optional, used for client auth) [1]                    |
 | KAFKA_SEC_CLIENT_CERT        | _unset_                               | PEM [2] for the client certificate (optional, used for client auth) [1]            |
 | KAFKA_SEC_CA_CERTS           | _unset_                               | PEM [2] of CA cert chain if using private CA for the server cert [1]               |

--- a/config/config.go
+++ b/config/config.go
@@ -68,6 +68,8 @@ type Config struct {
 	EnableMapsAPI              bool          `envconfig:"ENABLE_MAPS_API"`
 	MapsAPIURL                 string        `envconfig:"MAPS_API_URL"`
 	MapsAPIVersions            []string      `envconfig:"MAPS_API_VERSIONS"`
+	GeodataAPIURL              string        `envconfig:"GEODATA_API_URL"`
+	GeodataAPIVersions         []string      `envconfig:"GEODATA_API_VERSIONS"`
 }
 
 var cfg *Config
@@ -134,6 +136,8 @@ func Get() (*Config, error) {
 		EnableMapsAPI:              false,
 		MapsAPIURL:                 "http://localhost:27900",
 		MapsAPIVersions:            []string{"v1"},
+		GeodataAPIURL:              "http://localhost:28200",
+		GeodataAPIVersions:         []string{"v1"},
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -69,6 +69,8 @@ func TestGetReturnsDefaultValues(t *testing.T) {
 			EnableMapsAPI:              false,
 			MapsAPIURL:                 "http://localhost:27900",
 			MapsAPIVersions:            []string{"v1"},
+			GeodataAPIURL:              "http://localhost:28200",
+			GeodataAPIVersions:         []string{"v1"},
 		})
 	})
 }

--- a/service/service.go
+++ b/service/service.go
@@ -185,6 +185,7 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		filesApi := proxy.NewAPIProxy(ctx, cfg.FilesAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		downloadService := proxy.NewAPIProxy(ctx, cfg.DownloadServiceURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		permissionsAPIProxy := proxy.NewAPIProxy(ctx, cfg.PermissionsAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+		geodataAPIproxy := proxy.NewAPIProxy(ctx, cfg.GeodataAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		addTransitionalHandler(router, recipe, "/recipes")
 		addTransitionalHandler(router, importAPI, "/jobs")
 		addTransitionalHandler(router, dataset, "/instances")
@@ -199,6 +200,7 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		addVersionedHandlers(router, permissionsAPIProxy, cfg.PermissionsAPIVersions, "/policies")
 		addVersionedHandlers(router, permissionsAPIProxy, cfg.PermissionsAPIVersions, "/roles")
 		addVersionedHandlers(router, permissionsAPIProxy, cfg.PermissionsAPIVersions, "/permissions-bundle")
+		addVersionedHandlers(router, geodataAPIproxy, cfg.GeodataAPIVersions, "/geodata")
 
 		// Feature flag for Sessions API
 		if cfg.EnableSessionsAPI {


### PR DESCRIPTION
### What

add dp-geodata-api (private, versioned) to /geodata route
- Add private versioned proxy from /geodata to cfg.GeodataAPIURL
- Add tests for proxying to service_test.go
- Add config tests to config_test.go

### How to review

Run tests
run both dp-api-router and dp-geodata-api locally and check requests to localhost:23200/v1/geodata/metadata (e.g.) are proxied properly

### Who can review

Anyone