### PR TITLE
move geodata api from private to public

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -68,6 +68,7 @@ type Config struct {
 	EnableMapsAPI              bool          `envconfig:"ENABLE_MAPS_API"`
 	MapsAPIURL                 string        `envconfig:"MAPS_API_URL"`
 	MapsAPIVersions            []string      `envconfig:"MAPS_API_VERSIONS"`
+	EnableGeodataAPI           bool          `envconfig:"ENABLE_GEODATA_API"`
 	GeodataAPIURL              string        `envconfig:"GEODATA_API_URL"`
 	GeodataAPIVersions         []string      `envconfig:"GEODATA_API_VERSIONS"`
 }
@@ -136,6 +137,7 @@ func Get() (*Config, error) {
 		EnableMapsAPI:              false,
 		MapsAPIURL:                 "http://localhost:27900",
 		MapsAPIVersions:            []string{"v1"},
+		EnableGeodataAPI:           false,
 		GeodataAPIURL:              "http://localhost:28200",
 		GeodataAPIVersions:         []string{"v1"},
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -69,6 +69,7 @@ func TestGetReturnsDefaultValues(t *testing.T) {
 			EnableMapsAPI:              false,
 			MapsAPIURL:                 "http://localhost:27900",
 			MapsAPIVersions:            []string{"v1"},
+			EnableGeodataAPI:           false,
 			GeodataAPIURL:              "http://localhost:28200",
 			GeodataAPIVersions:         []string{"v1"},
 		})

--- a/service/service.go
+++ b/service/service.go
@@ -175,6 +175,10 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		mapsProxy := proxy.NewAPIProxy(ctx, cfg.MapsAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		addVersionedHandlers(router, mapsProxy, cfg.MapsAPIVersions, "/maps")
 	}
+	if cfg.EnableGeodataAPI {
+		geodataAPIproxy := proxy.NewAPIProxy(ctx, cfg.GeodataAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+		addVersionedHandlers(router, geodataAPIproxy, cfg.GeodataAPIVersions, "/geodata")
+	}
 
 	// Private APIs
 	if cfg.EnablePrivateEndpoints {
@@ -185,7 +189,6 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		filesApi := proxy.NewAPIProxy(ctx, cfg.FilesAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		downloadService := proxy.NewAPIProxy(ctx, cfg.DownloadServiceURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		permissionsAPIProxy := proxy.NewAPIProxy(ctx, cfg.PermissionsAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-		geodataAPIproxy := proxy.NewAPIProxy(ctx, cfg.GeodataAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		addTransitionalHandler(router, recipe, "/recipes")
 		addTransitionalHandler(router, importAPI, "/jobs")
 		addTransitionalHandler(router, dataset, "/instances")
@@ -200,7 +203,6 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		addVersionedHandlers(router, permissionsAPIProxy, cfg.PermissionsAPIVersions, "/policies")
 		addVersionedHandlers(router, permissionsAPIProxy, cfg.PermissionsAPIVersions, "/roles")
 		addVersionedHandlers(router, permissionsAPIProxy, cfg.PermissionsAPIVersions, "/permissions-bundle")
-		addVersionedHandlers(router, geodataAPIproxy, cfg.GeodataAPIVersions, "/geodata")
 
 		// Feature flag for Sessions API
 		if cfg.EnableSessionsAPI {


### PR DESCRIPTION
### What

Move dp-geodata-api proxy from private APIs to public ones +
refactor tests. This change needed as the API must be accessible
to the web VPC.

### How to review

Run tests, read the code

### Who can review

Anyone