### PR TITLE
Forward /areas requests to Dimension API (#5665)

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -162,6 +162,7 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 	addTransitionalHandler(router, dimensionSearch, "/dimension-search")
 	addTransitionalHandler(router, image, "/images")
 	addTransitionalHandler(router, dimensions, "/area-types")
+	addTransitionalHandler(router, dimensions, "/areas")
 
 	if cfg.EnablePopulationTypesAPI {
 		populationTypesAPI := proxy.NewAPIProxy(ctx, cfg.PopulationTypesAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -83,6 +83,7 @@ func TestRouterPublicAPIs(t *testing.T) {
 			"/images":           imageAPIURL,
 			"/population-types": populationTypesAPIURL,
 			"/area-types":       dimensionsAPIURL,
+			"/areas":            dimensionsAPIURL,
 		}
 		cfg.ArticlesAPIVersions = []string{"a", "b"}
 		for _, version := range cfg.ArticlesAPIVersions {
@@ -384,6 +385,12 @@ func TestRouterPublicAPIs(t *testing.T) {
 			w := createRouterTest(cfg, "http://localhost:23200/v1/area-types")
 			So(w.Code, ShouldEqual, http.StatusOK)
 			verifyProxied("/area-types", dimensionsAPIURL)
+		})
+
+		Convey("A request to the dimensions areas endpoint is proxied to dimensionsAPIURL", func() {
+			w := createRouterTest(cfg, "http://localhost:23200/v1/areas")
+			So(w.Code, ShouldEqual, http.StatusOK)
+			verifyProxied("/areas", dimensionsAPIURL)
 		})
 
 		Convey("Given a maps service path", func() {


### PR DESCRIPTION
### What

Forwards `/areas` requests to the Dimension API. This will soon change to live under the Population Types API, but for now we're keeping it in line with the existing `/area-types` endpoint.

Resolves: 5665 (partial) https://trello.com/c/oJqRypat

### How to review

Sense check.

### Who can review

Anyone.
