### PR TITLE
Extend api router to route /navigation requests to topics API

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,0 +1,1 @@
+sonatype-2021-4899 # No upgrade available. Insufficient Session Expiration see https://ossindex.sonatype.org/vulnerability/sonatype-2021-4899?component-type=golang&component-name=github.com/gorilla/sessions

--- a/service/service.go
+++ b/service/service.go
@@ -132,10 +132,13 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		observation := proxy.NewAPIProxy(ctx, cfg.ObservationAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
 		addTransitionalHandler(router, observation, "/datasets/{dataset_id}/editions/{edition}/versions/{version}/observations")
 	}
+
+	topic := proxy.NewAPIProxy(ctx, cfg.TopicAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
 	if cfg.EnableTopicAPI {
-		topic := proxy.NewAPIProxy(ctx, cfg.TopicAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
 		addTransitionalHandler(router, topic, "/topics")
 	}
+	addTransitionalHandler(router, topic, "/navigation")
+
 	codeList := proxy.NewAPIProxy(ctx, cfg.CodelistAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	dataset := proxy.NewAPIProxy(ctx, cfg.DatasetAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
 	filter := proxy.NewAPIProxy(ctx, cfg.FilterAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)


### PR DESCRIPTION
### What

See title

### How to review

Check `/navigation` endpoint routes requests to topics API

### Who can review

Anyone
