### PR TITLE
Release 1.23.0

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,0 +1,1 @@
+sonatype-2021-4899 # No upgrade available. Insufficient Session Expiration see https://ossindex.sonatype.org/vulnerability/sonatype-2021-4899?component-type=golang&component-name=github.com/gorilla/sessions

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ all: audit test build
 
 .PHONY: audit
 audit:
-	go list -m all | nancy sleuth
+	set -o pipefail; go list -m all | nancy sleuth
 
 .PHONY: build
 build:
@@ -25,8 +25,12 @@ build:
 
 .PHONY: test
 test:
-	go test -race -cover ./...
+	go test -count=1 -race -cover ./...
 
 .PHONY: debug
 debug:
 	HUMAN_LOG=1 go run -race -ldflags="-X 'main.BuildTime=$(BUILD_TIME)' -X 'main.GitCommit=$(GIT_COMMIT)' -X 'main.Version=$(VERSION)'" main.go
+
+.PHONY: generate
+generate:
+	go generate -v ./...

--- a/Makefile
+++ b/Makefile
@@ -30,5 +30,3 @@ test:
 .PHONY: debug
 debug:
 	HUMAN_LOG=1 go run -race -ldflags="-X 'main.BuildTime=$(BUILD_TIME)' -X 'main.GitCommit=$(GIT_COMMIT)' -X 'main.Version=$(VERSION)'" main.go
-
-.PHONY: test build debug

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This service is responsible for serving a JSON-LD `@context` field on configured
 | ENABLE_RELEASE_CALENDAR_API  | false                                 | Flag to enable routing to the release calendar API                                 |
 | ENABLE_INTERACTIVES_API      | false                                 | Flag to enable routing to the interactives API                                     |
 | ENABLE_MAPS_API              | false                                 | Flag to enable routing to the maps API                                             |
+| ENABLE_AREAS_API             | false                                 | Flag to enable routing to the areas API                                            |
 | ENABLE_ZEBEDEE_AUDIT         | false                                 |                                                                                    |
 | CONTEXT_URL                  | ""                                    | A URL to the JSON-LD context file describing the APIs                              |
 | API_POC_URL                  | "http://localhost:3000"               | A URL to the poc api                                                               |
@@ -55,6 +56,8 @@ This service is responsible for serving a JSON-LD `@context` field on configured
 | MAPS_API_VERSIONS:           | "v1"                                  | A comma delimted string with a list of versions supported by maps api              |
 | GEODATA_API_URL              | "http://localhost:28200"              | A URL to the geodata api                                                           |
 | GEODATA_API_VERSIONS         | "v1"                                  | A comma delimted string with a list of versions supported by geodata api           |
+| AREAS_API_URL                | "http://localhost:25500"              | A URL to the areas API                                                             |
+| AREAS_API_VERSIONS           | "v1"                                  | A comma-delimited string list: versions supported by the areas API                 |
 | KAFKA_ADDR                   | localhost:9092                        | The list of kafka hosts                                                            |
 | KAFKA_MAX_BYTES              | 2000000                               | The maximum bytes that can be sent in an event to kafka topic                      |
 | KAFKA_VERSION                | "1.0.2"                               | The kafka version that this service expects to connect to                          |

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,8 @@ type Config struct {
 	RecipeAPIURL               string        `envconfig:"RECIPE_API_URL"`
 	ImportAPIURL               string        `envconfig:"IMPORT_API_URL"`
 	SearchAPIURL               string        `envconfig:"SEARCH_API_URL"`
+	SearchReindexAPIURL        string        `envconfig:"SEARCH_REINDEX_API_URL"`
+	SearchReindexAPIVersions   []string      `envconfig:"SEARCH_REINDEX_API_VERSIONS"`
 	DimensionSearchAPIURL      string        `envconfig:"DIMENSION_SEARCH_API_URL"`
 	ImageAPIURL                string        `envconfig:"IMAGE_API_URL"`
 	UploadServiceAPIURL        string        `envconfig:"UPLOAD_SERVICE_API_URL"`
@@ -103,6 +105,8 @@ func Get() (*Config, error) {
 		RecipeAPIURL:               "http://localhost:22300",
 		ImportAPIURL:               "http://localhost:21800",
 		SearchAPIURL:               "http://localhost:23900",
+		SearchReindexAPIURL:        "http://localhost:25700",
+		SearchReindexAPIVersions:   []string{"v1"},
 		DimensionSearchAPIURL:      "http://localhost:23100",
 		DownloadServiceURL:         "http://localhost:23600",
 		ImageAPIURL:                "http://localhost:24700",

--- a/config/config.go
+++ b/config/config.go
@@ -72,6 +72,9 @@ type Config struct {
 	EnableGeodataAPI           bool          `envconfig:"ENABLE_GEODATA_API"`
 	GeodataAPIURL              string        `envconfig:"GEODATA_API_URL"`
 	GeodataAPIVersions         []string      `envconfig:"GEODATA_API_VERSIONS"`
+	EnableAreasAPI             bool          `envconfig:"ENABLE_AREAS_API"`
+	AreasAPIURL                string        `envconfig:"AREAS_API_URL"`
+	AreasAPIVersions           []string      `envconfig:"AREAS_API_VERSIONS"`
 }
 
 var cfg *Config
@@ -124,6 +127,9 @@ func Get() (*Config, error) {
 		EnableSessionsAPI:          false,
 		TopicAPIURL:                "http://localhost:25300",
 		EnableTopicAPI:             false,
+		AreasAPIURL:                "http://localhost:25500",
+		EnableAreasAPI:             false,
+		AreasAPIVersions:           []string{"v1"},
 		ArticlesAPIURL:             "http://localhost:27000",
 		EnableArticlesAPI:          false,
 		ArticlesAPIVersions:        []string{"v1"},

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	ImageAPIURL                string        `envconfig:"IMAGE_API_URL"`
 	UploadServiceAPIURL        string        `envconfig:"UPLOAD_SERVICE_API_URL"`
 	DownloadServiceURL         string        `envconfig:"DOWNLOAD_SERVICE_URL"`
+	EnableFilesAPI             bool          `envconfig:"ENABLE_FILES_API"`
 	FilesAPIURL                string        `envconfig:"FILES_API_URL"`
 	IdentityAPIURL             string        `envconfig:"IDENTITY_API_URL"`
 	IdentityAPIVersions        []string      `envconfig:"IDENTITY_API_VERSIONS"`
@@ -89,6 +90,7 @@ func Get() (*Config, error) {
 		EnableObservationAPI:       false,
 		EnableAudit:                false,
 		EnableZebedeeAudit:         false,
+		EnableFilesAPI:             false,
 		ZebedeeURL:                 "http://localhost:8082",
 		HierarchyAPIURL:            "http://localhost:22600",
 		FilterAPIURL:               "http://localhost:22100",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -73,6 +73,9 @@ func TestGetReturnsDefaultValues(t *testing.T) {
 			EnableGeodataAPI:           false,
 			GeodataAPIURL:              "http://localhost:28200",
 			GeodataAPIVersions:         []string{"v1"},
+			EnableAreasAPI:             false,
+			AreasAPIURL:                "http://localhost:25500",
+			AreasAPIVersions:           []string{"v1"},
 		})
 	})
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -39,6 +39,8 @@ func TestGetReturnsDefaultValues(t *testing.T) {
 			PermissionsAPIURL:          "http://localhost:25400",
 			PermissionsAPIVersions:     []string{"v1"},
 			SearchAPIURL:               "http://localhost:23900",
+			SearchReindexAPIURL:        "http://localhost:25700",
+			SearchReindexAPIVersions:   []string{"v1"},
 			DimensionSearchAPIURL:      "http://localhost:23100",
 			APIPocURL:                  "http://localhost:3000",
 			ContextURL:                 "",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -21,6 +21,7 @@ func TestGetReturnsDefaultValues(t *testing.T) {
 			EnableObservationAPI:       false,
 			EnableAudit:                false,
 			EnableZebedeeAudit:         false,
+			EnableFilesAPI:             false,
 			ZebedeeURL:                 "http://localhost:8082",
 			HierarchyAPIURL:            "http://localhost:22600",
 			FilterAPIURL:               "http://localhost:22100",

--- a/event/mock/marshaller.go
+++ b/event/mock/marshaller.go
@@ -14,19 +14,19 @@ var _ event.Marshaller = &MarshallerMock{}
 
 // MarshallerMock is a mock implementation of event.Marshaller.
 //
-//     func TestSomethingThatUsesMarshaller(t *testing.T) {
+// 	func TestSomethingThatUsesMarshaller(t *testing.T) {
 //
-//         // make and configure a mocked event.Marshaller
-//         mockedMarshaller := &MarshallerMock{
-//             MarshalFunc: func(s interface{}) ([]byte, error) {
-// 	               panic("mock out the Marshal method")
-//             },
-//         }
+// 		// make and configure a mocked event.Marshaller
+// 		mockedMarshaller := &MarshallerMock{
+// 			MarshalFunc: func(s interface{}) ([]byte, error) {
+// 				panic("mock out the Marshal method")
+// 			},
+// 		}
 //
-//         // use mockedMarshaller in code that requires event.Marshaller
-//         // and then make assertions.
+// 		// use mockedMarshaller in code that requires event.Marshaller
+// 		// and then make assertions.
 //
-//     }
+// 	}
 type MarshallerMock struct {
 	// MarshalFunc mocks the Marshal method.
 	MarshalFunc func(s interface{}) ([]byte, error)

--- a/middleware/mock/router.go
+++ b/middleware/mock/router.go
@@ -16,19 +16,19 @@ var _ middleware.Router = &RouterMock{}
 
 // RouterMock is a mock implementation of middleware.Router.
 //
-//     func TestSomethingThatUsesRouter(t *testing.T) {
+// 	func TestSomethingThatUsesRouter(t *testing.T) {
 //
-//         // make and configure a mocked middleware.Router
-//         mockedRouter := &RouterMock{
-//             MatchFunc: func(req *http.Request, match *mux.RouteMatch) bool {
-// 	               panic("mock out the Match method")
-//             },
-//         }
+// 		// make and configure a mocked middleware.Router
+// 		mockedRouter := &RouterMock{
+// 			MatchFunc: func(req *http.Request, match *mux.RouteMatch) bool {
+// 				panic("mock out the Match method")
+// 			},
+// 		}
 //
-//         // use mockedRouter in code that requires middleware.Router
-//         // and then make assertions.
+// 		// use mockedRouter in code that requires middleware.Router
+// 		// and then make assertions.
 //
-//     }
+// 	}
 type RouterMock struct {
 	// MatchFunc mocks the Match method.
 	MatchFunc func(req *http.Request, match *mux.RouteMatch) bool

--- a/proxy/mock/reverse_proxy.go
+++ b/proxy/mock/reverse_proxy.go
@@ -15,19 +15,19 @@ var _ proxy.IReverseProxy = &IReverseProxyMock{}
 
 // IReverseProxyMock is a mock implementation of proxy.IReverseProxy.
 //
-//     func TestSomethingThatUsesIReverseProxy(t *testing.T) {
+// 	func TestSomethingThatUsesIReverseProxy(t *testing.T) {
 //
-//         // make and configure a mocked proxy.IReverseProxy
-//         mockedIReverseProxy := &IReverseProxyMock{
-//             ServeHTTPFunc: func(rw http.ResponseWriter, req *http.Request)  {
-// 	               panic("mock out the ServeHTTP method")
-//             },
-//         }
+// 		// make and configure a mocked proxy.IReverseProxy
+// 		mockedIReverseProxy := &IReverseProxyMock{
+// 			ServeHTTPFunc: func(rw http.ResponseWriter, req *http.Request)  {
+// 				panic("mock out the ServeHTTP method")
+// 			},
+// 		}
 //
-//         // use mockedIReverseProxy in code that requires proxy.IReverseProxy
-//         // and then make assertions.
+// 		// use mockedIReverseProxy in code that requires proxy.IReverseProxy
+// 		// and then make assertions.
 //
-//     }
+// 	}
 type IReverseProxyMock struct {
 	// ServeHTTPFunc mocks the ServeHTTP method.
 	ServeHTTPFunc func(rw http.ResponseWriter, req *http.Request)

--- a/service/mock/healthcheck.go
+++ b/service/mock/healthcheck.go
@@ -17,28 +17,28 @@ var _ service.HealthChecker = &HealthCheckerMock{}
 
 // HealthCheckerMock is a mock implementation of service.HealthChecker.
 //
-//     func TestSomethingThatUsesHealthChecker(t *testing.T) {
+// 	func TestSomethingThatUsesHealthChecker(t *testing.T) {
 //
-//         // make and configure a mocked service.HealthChecker
-//         mockedHealthChecker := &HealthCheckerMock{
-//             AddCheckFunc: func(name string, checker healthcheck.Checker) error {
-// 	               panic("mock out the AddCheck method")
-//             },
-//             HandlerFunc: func(w http.ResponseWriter, req *http.Request)  {
-// 	               panic("mock out the Handler method")
-//             },
-//             StartFunc: func(ctx context.Context)  {
-// 	               panic("mock out the Start method")
-//             },
-//             StopFunc: func()  {
-// 	               panic("mock out the Stop method")
-//             },
-//         }
+// 		// make and configure a mocked service.HealthChecker
+// 		mockedHealthChecker := &HealthCheckerMock{
+// 			AddCheckFunc: func(name string, checker healthcheck.Checker) error {
+// 				panic("mock out the AddCheck method")
+// 			},
+// 			HandlerFunc: func(w http.ResponseWriter, req *http.Request)  {
+// 				panic("mock out the Handler method")
+// 			},
+// 			StartFunc: func(ctx context.Context)  {
+// 				panic("mock out the Start method")
+// 			},
+// 			StopFunc: func()  {
+// 				panic("mock out the Stop method")
+// 			},
+// 		}
 //
-//         // use mockedHealthChecker in code that requires service.HealthChecker
-//         // and then make assertions.
+// 		// use mockedHealthChecker in code that requires service.HealthChecker
+// 		// and then make assertions.
 //
-//     }
+// 	}
 type HealthCheckerMock struct {
 	// AddCheckFunc mocks the AddCheck method.
 	AddCheckFunc func(name string, checker healthcheck.Checker) error

--- a/service/mock/initialiser.go
+++ b/service/mock/initialiser.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"github.com/ONSdigital/dp-api-router/config"
 	"github.com/ONSdigital/dp-api-router/service"
-	"github.com/ONSdigital/dp-kafka/v2"
+	kafka "github.com/ONSdigital/dp-kafka/v2"
 	"sync"
 )
 
@@ -17,22 +17,22 @@ var _ service.Initialiser = &InitialiserMock{}
 
 // InitialiserMock is a mock implementation of service.Initialiser.
 //
-//     func TestSomethingThatUsesInitialiser(t *testing.T) {
+// 	func TestSomethingThatUsesInitialiser(t *testing.T) {
 //
-//         // make and configure a mocked service.Initialiser
-//         mockedInitialiser := &InitialiserMock{
-//             DoGetHealthCheckFunc: func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error) {
-// 	               panic("mock out the DoGetHealthCheck method")
-//             },
-//             DoGetKafkaProducerFunc: func(ctx context.Context, cfg *config.Config, topic string) (kafka.IProducer, error) {
-// 	               panic("mock out the DoGetKafkaProducer method")
-//             },
-//         }
+// 		// make and configure a mocked service.Initialiser
+// 		mockedInitialiser := &InitialiserMock{
+// 			DoGetHealthCheckFunc: func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error) {
+// 				panic("mock out the DoGetHealthCheck method")
+// 			},
+// 			DoGetKafkaProducerFunc: func(ctx context.Context, cfg *config.Config, topic string) (kafka.IProducer, error) {
+// 				panic("mock out the DoGetKafkaProducer method")
+// 			},
+// 		}
 //
-//         // use mockedInitialiser in code that requires service.Initialiser
-//         // and then make assertions.
+// 		// use mockedInitialiser in code that requires service.Initialiser
+// 		// and then make assertions.
 //
-//     }
+// 	}
 type InitialiserMock struct {
 	// DoGetHealthCheckFunc mocks the DoGetHealthCheck method.
 	DoGetHealthCheckFunc func(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error)

--- a/service/service.go
+++ b/service/service.go
@@ -132,10 +132,13 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		observation := proxy.NewAPIProxy(ctx, cfg.ObservationAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
 		addTransitionalHandler(router, observation, "/datasets/{dataset_id}/editions/{edition}/versions/{version}/observations")
 	}
+
+	topic := proxy.NewAPIProxy(ctx, cfg.TopicAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
 	if cfg.EnableTopicAPI {
-		topic := proxy.NewAPIProxy(ctx, cfg.TopicAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
 		addTransitionalHandler(router, topic, "/topics")
 	}
+	addTransitionalHandler(router, topic, "/navigation")
+
 	codeList := proxy.NewAPIProxy(ctx, cfg.CodelistAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	dataset := proxy.NewAPIProxy(ctx, cfg.DatasetAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
 	filter := proxy.NewAPIProxy(ctx, cfg.FilterAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)

--- a/service/service.go
+++ b/service/service.go
@@ -238,7 +238,7 @@ func addVersionedHandlers(router *mux.Router, proxy *proxy.APIProxy, versions []
 
 func addTransitionalHandler(router *mux.Router, proxy *proxy.APIProxy, path string) {
 	// Proxy any request after the path given to the target address
-	router.HandleFunc(fmt.Sprintf("/%s"+path+"{rest:/.*}", proxy.Version), proxy.LegacyHandle)
+	router.HandleFunc(fmt.Sprintf("/%s"+path+"{rest:$|/.*}", proxy.Version), proxy.LegacyHandle)
 }
 
 func addLegacyHandler(router *mux.Router, proxy *proxy.APIProxy, path string) {

--- a/service/service.go
+++ b/service/service.go
@@ -152,6 +152,10 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		articles := proxy.NewAPIProxy(ctx, cfg.ArticlesAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		addVersionedHandlers(router, articles, cfg.ArticlesAPIVersions, "/articles")
 	}
+	if cfg.EnableAreasAPI {
+		areas := proxy.NewAPIProxy(ctx, cfg.AreasAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+		addVersionedHandlers(router, areas, cfg.AreasAPIVersions, "/areas")
+	}
 	if cfg.EnableReleaseCalendarAPI {
 		releaseCalendar := proxy.NewAPIProxy(ctx, cfg.ReleaseCalendarAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		addVersionedHandlers(router, releaseCalendar, cfg.ReleaseCalendarAPIVersions, "/releases")
@@ -165,7 +169,6 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 	addTransitionalHandler(router, dimensionSearch, "/dimension-search")
 	addTransitionalHandler(router, image, "/images")
 	addTransitionalHandler(router, dimensions, "/area-types")
-	addTransitionalHandler(router, dimensions, "/areas")
 
 	if cfg.EnablePopulationTypesAPI {
 		populationTypesAPI := proxy.NewAPIProxy(ctx, cfg.PopulationTypesAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)

--- a/service/service.go
+++ b/service/service.go
@@ -187,16 +187,12 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		importAPI := proxy.NewAPIProxy(ctx, cfg.ImportAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		uploadServiceAPI := proxy.NewAPIProxy(ctx, cfg.UploadServiceAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		identityAPI := proxy.NewAPIProxy(ctx, cfg.IdentityAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-		filesApi := proxy.NewAPIProxy(ctx, cfg.FilesAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		downloadService := proxy.NewAPIProxy(ctx, cfg.DownloadServiceURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		permissionsAPIProxy := proxy.NewAPIProxy(ctx, cfg.PermissionsAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		addTransitionalHandler(router, recipe, "/recipes")
 		addTransitionalHandler(router, importAPI, "/jobs")
 		addTransitionalHandler(router, dataset, "/instances")
 		addTransitionalHandler(router, uploadServiceAPI, "/upload")
-		addTransitionalHandler(router, uploadServiceAPI, "/upload-new")
-		addTransitionalHandler(router, filesApi, "/files")
-		addTransitionalHandler(router, downloadService, "/downloads-new")
 		addVersionedHandlers(router, identityAPI, cfg.IdentityAPIVersions, "/tokens")
 		addVersionedHandlers(router, identityAPI, cfg.IdentityAPIVersions, "/users")
 		addVersionedHandlers(router, identityAPI, cfg.IdentityAPIVersions, "/groups")
@@ -209,6 +205,14 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		if cfg.EnableSessionsAPI {
 			session := proxy.NewAPIProxy(ctx, cfg.SessionsAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 			addTransitionalHandler(router, session, "/sessions")
+		}
+
+		// Feature flag for Files API
+		if cfg.EnableFilesAPI {
+			filesApi := proxy.NewAPIProxy(ctx, cfg.FilesAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+			addTransitionalHandler(router, filesApi, "/files")
+			addTransitionalHandler(router, uploadServiceAPI, "/upload-new")
+			addTransitionalHandler(router, downloadService, "/downloads-new")
 		}
 	}
 

--- a/service/service.go
+++ b/service/service.go
@@ -202,6 +202,7 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		uploadServiceAPI := proxy.NewAPIProxy(ctx, cfg.UploadServiceAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		identityAPI := proxy.NewAPIProxy(ctx, cfg.IdentityAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		permissionsAPIProxy := proxy.NewAPIProxy(ctx, cfg.PermissionsAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+		searchReindexAPI := proxy.NewAPIProxy(ctx, cfg.SearchReindexAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		addTransitionalHandler(router, recipe, "/recipes")
 		addTransitionalHandler(router, importAPI, "/jobs")
 		addTransitionalHandler(router, dataset, "/instances")
@@ -213,6 +214,7 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		addVersionedHandlers(router, permissionsAPIProxy, cfg.PermissionsAPIVersions, "/policies")
 		addVersionedHandlers(router, permissionsAPIProxy, cfg.PermissionsAPIVersions, "/roles")
 		addVersionedHandlers(router, permissionsAPIProxy, cfg.PermissionsAPIVersions, "/permissions-bundle")
+		addVersionedHandlers(router, searchReindexAPI, cfg.SearchReindexAPIVersions, "/search-reindex-jobs")
 
 		// Feature flag for Sessions API
 		if cfg.EnableSessionsAPI {

--- a/service/service.go
+++ b/service/service.go
@@ -184,13 +184,20 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		addVersionedHandlers(router, geodataAPIproxy, cfg.GeodataAPIVersions, "/geodata")
 	}
 
+	if cfg.EnableFilesAPI {
+		downloadService := proxy.NewAPIProxy(ctx, cfg.DownloadServiceURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+		filesApi := proxy.NewAPIProxy(ctx, cfg.FilesAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+
+		addTransitionalHandler(router, filesApi, "/files")
+		addTransitionalHandler(router, downloadService, "/downloads-new")
+	}
+
 	// Private APIs
 	if cfg.EnablePrivateEndpoints {
 		recipe := proxy.NewAPIProxy(ctx, cfg.RecipeAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		importAPI := proxy.NewAPIProxy(ctx, cfg.ImportAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		uploadServiceAPI := proxy.NewAPIProxy(ctx, cfg.UploadServiceAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		identityAPI := proxy.NewAPIProxy(ctx, cfg.IdentityAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-		downloadService := proxy.NewAPIProxy(ctx, cfg.DownloadServiceURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		permissionsAPIProxy := proxy.NewAPIProxy(ctx, cfg.PermissionsAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		addTransitionalHandler(router, recipe, "/recipes")
 		addTransitionalHandler(router, importAPI, "/jobs")
@@ -212,10 +219,7 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 
 		// Feature flag for Files API
 		if cfg.EnableFilesAPI {
-			filesApi := proxy.NewAPIProxy(ctx, cfg.FilesAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-			addTransitionalHandler(router, filesApi, "/files")
 			addTransitionalHandler(router, uploadServiceAPI, "/upload-new")
-			addTransitionalHandler(router, downloadService, "/downloads-new")
 		}
 	}
 

--- a/service/service.go
+++ b/service/service.go
@@ -238,7 +238,7 @@ func addVersionedHandlers(router *mux.Router, proxy *proxy.APIProxy, versions []
 
 func addTransitionalHandler(router *mux.Router, proxy *proxy.APIProxy, path string) {
 	// Proxy any request after the path given to the target address
-	router.HandleFunc(fmt.Sprintf("/%s"+path+"{rest:.*}", proxy.Version), proxy.LegacyHandle)
+	router.HandleFunc(fmt.Sprintf("/%s"+path+"{rest:/.*}", proxy.Version), proxy.LegacyHandle)
 }
 
 func addLegacyHandler(router *mux.Router, proxy *proxy.APIProxy, path string) {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -636,13 +636,13 @@ func TestRouterPrivateAPIs(t *testing.T) {
 			})
 
 			Convey("A request to a jobs path is proxied to uploadServiceAPIURL", func() {
-				w := createRouterTest(cfg, "http://localhost:25100/v1/upload")
+				w := createRouterTest(cfg, "http://localhost:23200/v1/upload")
 				So(w.Code, ShouldEqual, http.StatusOK)
 				verifyProxied("/upload", uploadServiceAPIURL)
 			})
 
 			Convey("A request to a jobs subpath is proxied to uploadServiceAPIURL", func() {
-				w := createRouterTest(cfg, "http://localhost:25100/v1/upload/subpath")
+				w := createRouterTest(cfg, "http://localhost:23200/v1/upload/subpath")
 				So(w.Code, ShouldEqual, http.StatusOK)
 				verifyProxied("/upload/subpath", uploadServiceAPIURL)
 			})


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- Ensure Downloads and Files endpoint available in Web and Publishing by @braddle in https://github.com/ONSdigital/dp-api-router/pull/155
- Add /areas endpoint to go to areas-api (and not dimensionsAPI) by @gedge in https://github.com/ONSdigital/dp-api-router/pull/158
- Test to use api router port by @rafahop in https://github.com/ONSdigital/dp-api-router/pull/160
- Add search-reindex-api endpoints for publishing @justinpjose in https://github.com/ONSdigital/dp-api-router/pull/161

**Release PR: https://github.com/ONSdigital/dp-api-router/pull/162**

### How to review
**Describe the steps required to test the changes.**
- Check if the changes make sense
- Check if the test passes

### Who can review
**Describe who worked on the changes, so that other people can review.**
- Anyone