### PR TITLE
Release v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ This service is responsible for serving a JSON-LD `@context` field on configured
 | INTERACTIVES_API_URL         | "http://localhost:27500"              | A URL to the interactives api                                                      |
 | ZEBEDEE_URL                  | "http://localhost:8082"               | A URL to the zebedee service api                                                   |
 | INTERACTIVES_API_VERSIONS    | "v1"                                  | A comma delimted string with a list of versions supported by interactives api      |
-| DIMENSIONS_API_URL           | "http://localhost:27200"              | A URL to the dimensions api                                                        |
 | MAPS_API_URL:                | "http://localhost:27900"              | A URL to the maps api                                                              |
 | MAPS_API_VERSIONS:           | "v1"                                  | A comma delimted string with a list of versions supported by maps api              |
 | GEODATA_API_URL              | "http://localhost:28200"              | A URL to the geodata api                                                           |

--- a/config/config.go
+++ b/config/config.go
@@ -67,7 +67,6 @@ type Config struct {
 	EnableInteractivesAPI      bool          `envconfig:"ENABLE_INTERACTIVES_API"`
 	InteractivesAPIURL         string        `envconfig:"INTERACTIVES_API_URL"`
 	InteractivesAPIVersions    []string      `envconfig:"INTERACTIVES_API_VERSIONS"`
-	DimensionsAPIURL           string        `envconfig:"DIMENSIONS_API_URL"`
 	EnableMapsAPI              bool          `envconfig:"ENABLE_MAPS_API"`
 	MapsAPIURL                 string        `envconfig:"MAPS_API_URL"`
 	MapsAPIVersions            []string      `envconfig:"MAPS_API_VERSIONS"`
@@ -145,7 +144,6 @@ func Get() (*Config, error) {
 		InteractivesAPIURL:         "http://localhost:27500",
 		EnableInteractivesAPI:      false,
 		InteractivesAPIVersions:    []string{"v1"},
-		DimensionsAPIURL:           "http://localhost:27200",
 		EnableMapsAPI:              false,
 		MapsAPIURL:                 "http://localhost:27900",
 		MapsAPIVersions:            []string{"v1"},

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,8 @@ type Config struct {
 	RecipeAPIURL               string        `envconfig:"RECIPE_API_URL"`
 	ImportAPIURL               string        `envconfig:"IMPORT_API_URL"`
 	SearchAPIURL               string        `envconfig:"SEARCH_API_URL"`
+	SearchReindexAPIURL        string        `envconfig:"SEARCH_REINDEX_API_URL"`
+	SearchReindexAPIVersions   []string      `envconfig:"SEARCH_REINDEX_API_VERSIONS"`
 	DimensionSearchAPIURL      string        `envconfig:"DIMENSION_SEARCH_API_URL"`
 	ImageAPIURL                string        `envconfig:"IMAGE_API_URL"`
 	UploadServiceAPIURL        string        `envconfig:"UPLOAD_SERVICE_API_URL"`
@@ -103,6 +105,8 @@ func Get() (*Config, error) {
 		RecipeAPIURL:               "http://localhost:22300",
 		ImportAPIURL:               "http://localhost:21800",
 		SearchAPIURL:               "http://localhost:23900",
+		SearchReindexAPIURL:        "http://localhost:25700",
+		SearchReindexAPIVersions:   []string{"v1"},
 		DimensionSearchAPIURL:      "http://localhost:23100",
 		DownloadServiceURL:         "http://localhost:23600",
 		ImageAPIURL:                "http://localhost:24700",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -39,6 +39,8 @@ func TestGetReturnsDefaultValues(t *testing.T) {
 			PermissionsAPIURL:          "http://localhost:25400",
 			PermissionsAPIVersions:     []string{"v1"},
 			SearchAPIURL:               "http://localhost:23900",
+			SearchReindexAPIURL:        "http://localhost:25700",
+			SearchReindexAPIVersions:   []string{"v1"},
 			DimensionSearchAPIURL:      "http://localhost:23100",
 			APIPocURL:                  "http://localhost:3000",
 			ContextURL:                 "",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -68,7 +68,6 @@ func TestGetReturnsDefaultValues(t *testing.T) {
 			InteractivesAPIURL:         "http://localhost:27500",
 			EnableInteractivesAPI:      false,
 			InteractivesAPIVersions:    []string{"v1"},
-			DimensionsAPIURL:           "http://localhost:27200",
 			EnableMapsAPI:              false,
 			MapsAPIURL:                 "http://localhost:27900",
 			MapsAPIVersions:            []string{"v1"},

--- a/service/service.go
+++ b/service/service.go
@@ -5,6 +5,11 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/gorilla/handlers"
+	"github.com/gorilla/mux"
+	"github.com/justinas/alice"
+	"github.com/pkg/errors"
+
 	"github.com/ONSdigital/dp-api-clients-go/v2/health"
 	"github.com/ONSdigital/dp-api-router/config"
 	"github.com/ONSdigital/dp-api-router/event"
@@ -14,10 +19,6 @@ import (
 	kafka "github.com/ONSdigital/dp-kafka/v2"
 	dphttp "github.com/ONSdigital/dp-net/v2/http"
 	"github.com/ONSdigital/log.go/v2/log"
-	"github.com/gorilla/handlers"
-	"github.com/gorilla/mux"
-	"github.com/justinas/alice"
-	"github.com/pkg/errors"
 )
 
 // Service contains all the configs, server and clients to run the API Router
@@ -145,7 +146,7 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 	hierarchy := proxy.NewAPIProxy(ctx, cfg.HierarchyAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	search := proxy.NewAPIProxy(ctx, cfg.SearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	dimensionSearch := proxy.NewAPIProxy(ctx, cfg.DimensionSearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-	dimensions := proxy.NewAPIProxy(ctx, cfg.DimensionsAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
+	populations := proxy.NewAPIProxy(ctx, cfg.PopulationTypesAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
 	image := proxy.NewAPIProxy(ctx, cfg.ImageAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 
 	if cfg.EnableArticlesAPI {
@@ -168,7 +169,7 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 	addTransitionalHandler(router, search, "/search")
 	addTransitionalHandler(router, dimensionSearch, "/dimension-search")
 	addTransitionalHandler(router, image, "/images")
-	addTransitionalHandler(router, dimensions, "/area-types")
+	addTransitionalHandler(router, populations, "/area-types")
 
 	if cfg.EnablePopulationTypesAPI {
 		populationTypesAPI := proxy.NewAPIProxy(ctx, cfg.PopulationTypesAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)

--- a/service/service.go
+++ b/service/service.go
@@ -146,7 +146,6 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 	hierarchy := proxy.NewAPIProxy(ctx, cfg.HierarchyAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	search := proxy.NewAPIProxy(ctx, cfg.SearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	dimensionSearch := proxy.NewAPIProxy(ctx, cfg.DimensionSearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-	populations := proxy.NewAPIProxy(ctx, cfg.PopulationTypesAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
 	image := proxy.NewAPIProxy(ctx, cfg.ImageAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 
 	if cfg.EnableArticlesAPI {
@@ -169,7 +168,6 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 	addTransitionalHandler(router, search, "/search")
 	addTransitionalHandler(router, dimensionSearch, "/dimension-search")
 	addTransitionalHandler(router, image, "/images")
-	addTransitionalHandler(router, populations, "/area-types")
 
 	if cfg.EnablePopulationTypesAPI {
 		populationTypesAPI := proxy.NewAPIProxy(ctx, cfg.PopulationTypesAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)

--- a/service/service.go
+++ b/service/service.go
@@ -202,6 +202,7 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		uploadServiceAPI := proxy.NewAPIProxy(ctx, cfg.UploadServiceAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		identityAPI := proxy.NewAPIProxy(ctx, cfg.IdentityAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		permissionsAPIProxy := proxy.NewAPIProxy(ctx, cfg.PermissionsAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+		searchReindexAPI := proxy.NewAPIProxy(ctx, cfg.SearchReindexAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		addTransitionalHandler(router, recipe, "/recipes")
 		addTransitionalHandler(router, importAPI, "/jobs")
 		addTransitionalHandler(router, dataset, "/instances")
@@ -213,6 +214,7 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		addVersionedHandlers(router, permissionsAPIProxy, cfg.PermissionsAPIVersions, "/policies")
 		addVersionedHandlers(router, permissionsAPIProxy, cfg.PermissionsAPIVersions, "/roles")
 		addVersionedHandlers(router, permissionsAPIProxy, cfg.PermissionsAPIVersions, "/permissions-bundle")
+		addVersionedHandlers(router, searchReindexAPI, cfg.SearchReindexAPIVersions, "/search-reindex-jobs")
 
 		// Feature flag for Sessions API
 		if cfg.EnableSessionsAPI {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -636,13 +636,13 @@ func TestRouterPrivateAPIs(t *testing.T) {
 			})
 
 			Convey("A request to a jobs path is proxied to uploadServiceAPIURL", func() {
-				w := createRouterTest(cfg, "http://localhost:25100/v1/upload")
+				w := createRouterTest(cfg, "http://localhost:23200/v1/upload")
 				So(w.Code, ShouldEqual, http.StatusOK)
 				verifyProxied("/upload", uploadServiceAPIURL)
 			})
 
 			Convey("A request to a jobs subpath is proxied to uploadServiceAPIURL", func() {
-				w := createRouterTest(cfg, "http://localhost:25100/v1/upload/subpath")
+				w := createRouterTest(cfg, "http://localhost:23200/v1/upload/subpath")
 				So(w.Code, ShouldEqual, http.StatusOK)
 				verifyProxied("/upload/subpath", uploadServiceAPIURL)
 			})

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -67,7 +67,6 @@ func TestRouterPublicAPIs(t *testing.T) {
 		releaseCalendarAPIURL, _ := url.Parse(cfg.ReleaseCalendarAPIURL)
 		populationTypesAPIURL, _ := url.Parse(cfg.PopulationTypesAPIURL)
 		interactivesAPIURL, _ := url.Parse(cfg.InteractivesAPIURL)
-		dimensionsAPIURL, _ := url.Parse(cfg.DimensionsAPIURL)
 		mapsAPIURL, _ := url.Parse(cfg.MapsAPIURL)
 		geodataAPIURL, _ := url.Parse(cfg.GeodataAPIURL)
 		topicAPIURL, _ := url.Parse(cfg.TopicAPIURL)
@@ -84,7 +83,6 @@ func TestRouterPublicAPIs(t *testing.T) {
 			"/dimension-search": dimensionSearchAPIURL,
 			"/images":           imageAPIURL,
 			"/population-types": populationTypesAPIURL,
-			"/area-types":       dimensionsAPIURL,
 			"/navigation":       topicAPIURL,
 		}
 
@@ -384,12 +382,6 @@ func TestRouterPublicAPIs(t *testing.T) {
 					}
 				})
 			})
-		})
-
-		Convey("A request to the dimensions area-types endpoint is proxied to PopulationTypesAPIURL", func() {
-			w := createRouterTest(cfg, "http://localhost:23200/v1/area-types")
-			So(w.Code, ShouldEqual, http.StatusOK)
-			verifyProxied("/area-types", populationTypesAPIURL)
 		})
 
 		Convey("Given a topic service path", func() {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -386,10 +386,10 @@ func TestRouterPublicAPIs(t *testing.T) {
 			})
 		})
 
-		Convey("A request to the dimensions area-types endpoint is proxied to dimensionsAPIURL", func() {
+		Convey("A request to the dimensions area-types endpoint is proxied to PopulationTypesAPIURL", func() {
 			w := createRouterTest(cfg, "http://localhost:23200/v1/area-types")
 			So(w.Code, ShouldEqual, http.StatusOK)
-			verifyProxied("/area-types", dimensionsAPIURL)
+			verifyProxied("/area-types", populationTypesAPIURL)
 		})
 
 		Convey("Given a topic service path", func() {


### PR DESCRIPTION
### What

Since we are removing any use of DimensionsAPI route paths, this is a breaking change to any service that might still use it.
Therefore this is [classed as a major version change](https://semver.org/)

* [Remove DimensionsAPI route path](https://github.com/ONSdigital/dp-api-router/commit/78175bb04c96118ff9346ba3e961c115db2c24a9) - This service is no longer being used
* [Change router for area-types](https://github.com/ONSdigital/dp-api-router/commit/a6d777a83323fce665a99c5a8645fb0a3a000652)

### How to review

Sense check it

### Who can review

Any ONS developer
