### PR TITLE
Add missing test for /cantabular-metadata route

### DIFF
--- a/service/service_test.go
+++ b/service/service_test.go
@@ -754,11 +754,23 @@ func TestRouterPrivateAPIs(t *testing.T) {
 				}
 			})
 
-			Convey("A request to a cantabular-metadata subpath is proxied to cantabularMetadataExtractorAPIURL", func() {
+			Convey("When the enable cantabular metadata extractor API feature flag is enabled", func() {
 				cfg.EnableCantabularMetadataExtractorAPI = true
-				w := createRouterTest(cfg, "http://localhost:23200/v1/cantabular-metadata/subpath")
-				So(w.Code, ShouldEqual, http.StatusOK)
-				verifyProxied("/cantabular-metadata/subpath", cantabularMetadataExtractorAPIURL)
+
+				Convey("A request to a cantabular-metadata subpath is proxied to cantabularMetadataExtractorAPIURL", func() {
+					w := createRouterTest(cfg, "http://localhost:23200/v1/cantabular-metadata/subpath")
+					So(w.Code, ShouldEqual, http.StatusOK)
+					verifyProxied("/cantabular-metadata/subpath", cantabularMetadataExtractorAPIURL)
+				})
+			})
+
+			Convey("When the enable cantabular metadata extractor API feature flag is disabled", func() {
+				cfg.EnableCantabularMetadataExtractorAPI = false
+
+				Convey("A request to a cantabular-metadata subpath is not proxied", func() {
+					createRouterTest(cfg, "http://localhost:23200/v1/cantabular-metadata/subpath")
+					assertOnlyThisURLIsCalled(zebedeeURL)
+				})
 			})
 		})
 
@@ -800,9 +812,8 @@ func TestRouterPrivateAPIs(t *testing.T) {
 				assertOnlyThisURLIsCalled(zebedeeURL)
 			})
 
-			Convey("A request to a cantabular-metadata subpath is not proxied and fails with StatusNotFound", func() {
-				cfg.EnableCantabularMetadataExtractorAPI = false
-				createRouterTest(cfg, "http://localhost:23200/v1/cantabular-metadata")
+			Convey("A request to a cantabular-metadata subpath is not proxied", func() {
+				createRouterTest(cfg, "http://localhost:23200/v1/cantabular-metadata/subpath")
 				assertOnlyThisURLIsCalled(zebedeeURL)
 			})
 		})


### PR DESCRIPTION
### What

Test the case when the `metadata extractor api flag is disabled and private endpoints flag is enabled`.

### How to review

Run tests

### Who can review

Anyone
