### PR TITLE
Remove ENABLE_TOPIC_API flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ This service is responsible for serving a JSON-LD `@context` field on configured
 | ENABLE_PRIVATE_ENDPOINTS                   | true                     | If private endpoints should be routed                                                      |
 | ENABLE_V1_BETA_RESTRICTION                 | false                    |                                                                                            |
 | ENABLE_SESSIONS_API                        | false                    |                                                                                            |
-| ENABLE_TOPIC_API                           | false                    |                                                                                            |
 | ENABLE_ARTICLES_API                        | false                    | Flag to enable routing to the articles API                                                 |
 | ENABLE_RELEASE_CALENDAR_API                | false                    | Flag to enable routing to the release calendar API                                         |
 | ENABLE_INTERACTIVES_API                    | false                    | Flag to enable routing to the interactives API                                             |

--- a/config/config.go
+++ b/config/config.go
@@ -56,7 +56,6 @@ type Config struct {
 	SessionsAPIURL                       string        `envconfig:"SESSIONS_API_URL"`
 	EnableSessionsAPI                    bool          `envconfig:"ENABLE_SESSIONS_API"`
 	TopicAPIURL                          string        `envconfig:"TOPIC_API_URL"`
-	EnableTopicAPI                       bool          `envconfig:"ENABLE_TOPIC_API"`
 	EnableArticlesAPI                    bool          `envconfig:"ENABLE_ARTICLES_API"`
 	ArticlesAPIURL                       string        `envconfig:"ARTICLES_API_URL"`
 	ArticlesAPIVersions                  []string      `envconfig:"ARTICLES_API_VERSIONS"`
@@ -133,7 +132,6 @@ func Get() (*Config, error) {
 		SessionsAPIURL:                       "http://localhost:24400",
 		EnableSessionsAPI:                    false,
 		TopicAPIURL:                          "http://localhost:25300",
-		EnableTopicAPI:                       false,
 		AreasAPIURL:                          "http://localhost:25500",
 		EnableAreasAPI:                       false,
 		AreasAPIVersions:                     []string{"v1"},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -56,7 +56,6 @@ func TestGetReturnsDefaultValues(t *testing.T) {
 			SessionsAPIURL:                       "http://localhost:24400",
 			EnableSessionsAPI:                    false,
 			TopicAPIURL:                          "http://localhost:25300",
-			EnableTopicAPI:                       false,
 			ArticlesAPIURL:                       "http://localhost:27000",
 			EnableArticlesAPI:                    false,
 			ArticlesAPIVersions:                  []string{"v1"},

--- a/service/service.go
+++ b/service/service.go
@@ -134,9 +134,7 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 	}
 
 	topic := proxy.NewAPIProxy(ctx, cfg.TopicAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
-	if cfg.EnableTopicAPI {
-		addTransitionalHandler(router, topic, "/topics")
-	}
+	addTransitionalHandler(router, topic, "/topics")
 	addTransitionalHandler(router, topic, "/navigation")
 
 	codeList := proxy.NewAPIProxy(ctx, cfg.CodelistAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -80,6 +80,7 @@ func TestRouterPublicAPIs(t *testing.T) {
 			"/images":           imageAPIURL,
 			"/population-types": populationTypesAPIURL,
 			"/navigation":       topicAPIURL,
+			"/topics":           topicAPIURL,
 		}
 
 		cfg.ArticlesAPIVersions = []string{"a", "b"}
@@ -381,32 +382,22 @@ func TestRouterPublicAPIs(t *testing.T) {
 		})
 
 		Convey("Given a topic service path", func() {
-			Convey("When the feature flag is disabled", func() {
-				cfg.EnableTopicAPI = false
+			topicsPath := "http://localhost:23200/v1/topics"
 
-				Convey("Then a request to the topic navigation endpoint is proxied to topicsAPIURL", func() {
-					w := createRouterTest(cfg, "http://localhost:23200/v1/navigation")
-					So(w.Code, ShouldEqual, http.StatusOK)
-					verifyProxied("/navigation", topicAPIURL)
-				})
+			Convey("Then a request to the topics endpoint is proxied to the topicsAPIURL", func() {
+				w := createRouterTest(cfg, topicsPath)
+				So(w.Code, ShouldEqual, http.StatusOK)
+				verifyProxied("/topics", topicAPIURL)
+			})
+		})
 
-				Convey("And a request to the topics endpoint is not proxied to the topicsAPIURL", func() {
-					w := createRouterTest(cfg, "http://localhost:23200/v1/topics")
-					So(w.Code, ShouldEqual, http.StatusNotFound)
-				})
+		Convey("Given a navigation path", func() {
+			navigationPath := "http://localhost:23200/v1/navigation"
 
-				Convey("And when the feature flag is enabled", func() {
-					cfg.EnableTopicAPI = true
-
-					expectedPublicURLs["/topics"] = topicAPIURL
-					resetProxyMocksWithExpectations(expectedPublicURLs)
-
-					Convey("Then a request to the topics endpoint is proxied to the topicsAPIURL", func() {
-						w := createRouterTest(cfg, "http://localhost:23200/v1/topics")
-						So(w.Code, ShouldEqual, http.StatusOK)
-						verifyProxied("/topics", topicAPIURL)
-					})
-				})
+			Convey("Then a request to the navigation endpoint is proxied to topicsAPIURL", func() {
+				w := createRouterTest(cfg, navigationPath)
+				So(w.Code, ShouldEqual, http.StatusOK)
+				verifyProxied("/navigation", topicAPIURL)
 			})
 		})
 


### PR DESCRIPTION
### What

This feature flag is no longer required and can be safely removed.

### How to review

Make sure the code behaves in the same way as when the flag is true.

### Who can review

Anyone
