### PR TITLE
add routing for dataset-json endpoint

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	ZebedeeURL                           string        `envconfig:"ZEBEDEE_URL"`
 	HierarchyAPIURL                      string        `envconfig:"HIERARCHY_API_URL"`
 	FilterAPIURL                         string        `envconfig:"FILTER_API_URL"`
+	FilterFlexAPIURL                     string        `envconfig:"FILTER_FLEX_API_URL"`
 	DatasetAPIURL                        string        `envconfig:"DATASET_API_URL"`
 	ObservationAPIURL                    string        `envconfig:"OBSERVATION_API_URL"`
 	CodelistAPIURL                       string        `envconfig:"CODE_LIST_API_URL"`
@@ -101,6 +102,7 @@ func Get() (*Config, error) {
 		ZebedeeURL:                           "http://localhost:8082",
 		HierarchyAPIURL:                      "http://localhost:22600",
 		FilterAPIURL:                         "http://localhost:22100",
+		FilterFlexAPIURL:                     "http://localhost:27100",
 		DatasetAPIURL:                        "http://localhost:22000",
 		ObservationAPIURL:                    "http://localhost:24500",
 		CodelistAPIURL:                       "http://localhost:22400",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,6 +25,7 @@ func TestGetReturnsDefaultValues(t *testing.T) {
 			ZebedeeURL:                           "http://localhost:8082",
 			HierarchyAPIURL:                      "http://localhost:22600",
 			FilterAPIURL:                         "http://localhost:22100",
+			FilterFlexAPIURL:                     "http://localhost:27100",
 			DatasetAPIURL:                        "http://localhost:22000",
 			ObservationAPIURL:                    "http://localhost:24500",
 			CodelistAPIURL:                       "http://localhost:22400",

--- a/service/service.go
+++ b/service/service.go
@@ -142,6 +142,7 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 	codeList := proxy.NewAPIProxy(ctx, cfg.CodelistAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	dataset := proxy.NewAPIProxy(ctx, cfg.DatasetAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction)
 	filter := proxy.NewAPIProxy(ctx, cfg.FilterAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	filterFlex := proxy.NewAPIProxy(ctx, cfg.FilterFlexAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	hierarchy := proxy.NewAPIProxy(ctx, cfg.HierarchyAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	search := proxy.NewAPIProxy(ctx, cfg.SearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	dimensionSearch := proxy.NewAPIProxy(ctx, cfg.DimensionSearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
@@ -159,6 +160,9 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		releaseCalendar := proxy.NewAPIProxy(ctx, cfg.ReleaseCalendarAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		addVersionedHandlers(router, releaseCalendar, cfg.ReleaseCalendarAPIVersions, "/releases")
 	}
+
+	addTransitionalHandler(router, filterFlex, "/datasets/{dataset_id}/editions/{edition}/versions/{version}/json")
+
 	addTransitionalHandler(router, codeList, "/code-lists")
 	addTransitionalHandler(router, dataset, "/datasets")
 	addTransitionalHandler(router, filter, "/filters")

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -53,6 +53,7 @@ func TestRouterPublicAPIs(t *testing.T) {
 		zebedeeURL, _ := url.Parse(cfg.ZebedeeURL)
 		hierarchyAPIURL, _ := url.Parse(cfg.HierarchyAPIURL)
 		filterAPIURL, _ := url.Parse(cfg.FilterAPIURL)
+		filterFlexAPIURL, _ := url.Parse(cfg.FilterFlexAPIURL)
 		datasetAPIURL, _ := url.Parse(cfg.DatasetAPIURL)
 		observationAPIURL, _ := url.Parse(cfg.ObservationAPIURL)
 		codelistAPIURL, _ := url.Parse(cfg.CodelistAPIURL)
@@ -72,6 +73,7 @@ func TestRouterPublicAPIs(t *testing.T) {
 			"/code-lists": codelistAPIURL,
 			"/datasets":   datasetAPIURL,
 			"/datasets/{dataset_id}/editions/{edition}/versions/{version}/observations": observationAPIURL,
+			"/datasets/{dataset_id}/editions/{edition}/versions/{version}/json":         filterFlexAPIURL,
 			"/filters":          filterAPIURL,
 			"/filter-outputs":   filterAPIURL,
 			"/hierarchies":      hierarchyAPIURL,


### PR DESCRIPTION
### What

Added routing for `/datasets/{id}/editions/{edition}/versions/{version}/json` endpoint which sits on `dp-cantabular-filter-flex-api`

### How to review

Check changes make sense

### Who can review

Anyone