### PR TITLE
Remove articles api

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ This service is responsible for serving a JSON-LD `@context` field on configured
 | ENABLE_PRIVATE_ENDPOINTS                   | true                     | If private endpoints should be routed                                                      |
 | ENABLE_V1_BETA_RESTRICTION                 | false                    |                                                                                            |
 | ENABLE_SESSIONS_API                        | false                    |                                                                                            |
-| ENABLE_ARTICLES_API                        | false                    | Flag to enable routing to the articles API                                                 |
 | ENABLE_RELEASE_CALENDAR_API                | false                    | Flag to enable routing to the release calendar API                                         |
 | ENABLE_INTERACTIVES_API                    | false                    | Flag to enable routing to the interactives API                                             |
 | ENABLE_MAPS_API                            | false                    | Flag to enable routing to the maps API                                                     |
@@ -28,7 +27,6 @@ This service is responsible for serving a JSON-LD `@context` field on configured
 | ENABLE_ZEBEDEE_AUDIT                       | false                    |                                                                                            |
 | CONTEXT_URL                                | ""                       | A URL to the JSON-LD context file describing the APIs                                      |
 | API_POC_URL                                | "http://localhost:3000"  | A URL to the poc api                                                                       |
-| ARTICLES_API_URL                           | "http://localhost:27000" | A URL to the articles api                                                                  |
 | IMPORT_API_URL                             | "http://localhost:21800" | A URL to the import api                                                                    |
 | DATASET_API_URL                            | "http://localhost:22000" | A URL to the dataset api                                                                   |
 | FILTER_API_URL                             | "http://localhost:22100" | A URL to the filter api                                                                    |

--- a/config/config.go
+++ b/config/config.go
@@ -57,7 +57,6 @@ type Config struct {
 	SessionsAPIURL                       string        `envconfig:"SESSIONS_API_URL"`
 	EnableSessionsAPI                    bool          `envconfig:"ENABLE_SESSIONS_API"`
 	TopicAPIURL                          string        `envconfig:"TOPIC_API_URL"`
-	EnableArticlesAPI                    bool          `envconfig:"ENABLE_ARTICLES_API"`
 	ArticlesAPIURL                       string        `envconfig:"ARTICLES_API_URL"`
 	ArticlesAPIVersions                  []string      `envconfig:"ARTICLES_API_VERSIONS"`
 	EnableFeedbackAPI                    bool          `envconfig:"ENABLE_FEEDBACK_API"`
@@ -141,7 +140,6 @@ func Get() (*Config, error) {
 		EnableAreasAPI:                       false,
 		AreasAPIVersions:                     []string{"v1"},
 		ArticlesAPIURL:                       "http://localhost:27000",
-		EnableArticlesAPI:                    false,
 		ArticlesAPIVersions:                  []string{"v1"},
 		FeedbackAPIURL:                       "http://localhost:28600",
 		EnableFeedbackAPI:                    false,

--- a/config/config.go
+++ b/config/config.go
@@ -57,7 +57,6 @@ type Config struct {
 	SessionsAPIURL                       string        `envconfig:"SESSIONS_API_URL"`
 	EnableSessionsAPI                    bool          `envconfig:"ENABLE_SESSIONS_API"`
 	TopicAPIURL                          string        `envconfig:"TOPIC_API_URL"`
-	ArticlesAPIVersions                  []string      `envconfig:"ARTICLES_API_VERSIONS"`
 	EnableFeedbackAPI                    bool          `envconfig:"ENABLE_FEEDBACK_API"`
 	FeedbackAPIURL                       string        `envconfig:"FEEDBACK_API_URL"`
 	FeedbackAPIVersions                  []string      `envconfig:"FEEDBACK_API_VERSIONS"`
@@ -138,7 +137,6 @@ func Get() (*Config, error) {
 		AreasAPIURL:                          "http://localhost:25500",
 		EnableAreasAPI:                       false,
 		AreasAPIVersions:                     []string{"v1"},
-		ArticlesAPIVersions:                  []string{"v1"},
 		FeedbackAPIURL:                       "http://localhost:28600",
 		EnableFeedbackAPI:                    false,
 		FeedbackAPIVersions:                  []string{"v1"},

--- a/config/config.go
+++ b/config/config.go
@@ -57,7 +57,6 @@ type Config struct {
 	SessionsAPIURL                       string        `envconfig:"SESSIONS_API_URL"`
 	EnableSessionsAPI                    bool          `envconfig:"ENABLE_SESSIONS_API"`
 	TopicAPIURL                          string        `envconfig:"TOPIC_API_URL"`
-	ArticlesAPIURL                       string        `envconfig:"ARTICLES_API_URL"`
 	ArticlesAPIVersions                  []string      `envconfig:"ARTICLES_API_VERSIONS"`
 	EnableFeedbackAPI                    bool          `envconfig:"ENABLE_FEEDBACK_API"`
 	FeedbackAPIURL                       string        `envconfig:"FEEDBACK_API_URL"`
@@ -139,7 +138,6 @@ func Get() (*Config, error) {
 		AreasAPIURL:                          "http://localhost:25500",
 		EnableAreasAPI:                       false,
 		AreasAPIVersions:                     []string{"v1"},
-		ArticlesAPIURL:                       "http://localhost:27000",
 		ArticlesAPIVersions:                  []string{"v1"},
 		FeedbackAPIURL:                       "http://localhost:28600",
 		EnableFeedbackAPI:                    false,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -58,7 +58,6 @@ func TestGetReturnsDefaultValues(t *testing.T) {
 			EnableSessionsAPI:                    false,
 			TopicAPIURL:                          "http://localhost:25300",
 			ArticlesAPIURL:                       "http://localhost:27000",
-			EnableArticlesAPI:                    false,
 			ArticlesAPIVersions:                  []string{"v1"},
 			FeedbackAPIURL:                       "http://localhost:28600",
 			EnableFeedbackAPI:                    false,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -57,7 +57,6 @@ func TestGetReturnsDefaultValues(t *testing.T) {
 			SessionsAPIURL:                       "http://localhost:24400",
 			EnableSessionsAPI:                    false,
 			TopicAPIURL:                          "http://localhost:25300",
-			ArticlesAPIVersions:                  []string{"v1"},
 			FeedbackAPIURL:                       "http://localhost:28600",
 			EnableFeedbackAPI:                    false,
 			FeedbackAPIVersions:                  []string{"v1"},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -57,7 +57,6 @@ func TestGetReturnsDefaultValues(t *testing.T) {
 			SessionsAPIURL:                       "http://localhost:24400",
 			EnableSessionsAPI:                    false,
 			TopicAPIURL:                          "http://localhost:25300",
-			ArticlesAPIURL:                       "http://localhost:27000",
 			ArticlesAPIVersions:                  []string{"v1"},
 			FeedbackAPIURL:                       "http://localhost:28600",
 			EnableFeedbackAPI:                    false,

--- a/service/service.go
+++ b/service/service.go
@@ -148,10 +148,6 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 	dimensionSearch := proxy.NewAPIProxy(ctx, cfg.DimensionSearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	image := proxy.NewAPIProxy(ctx, cfg.ImageAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 
-	if cfg.EnableArticlesAPI {
-		articles := proxy.NewAPIProxy(ctx, cfg.ArticlesAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
-		addVersionedHandlers(router, articles, cfg.ArticlesAPIVersions, "/articles")
-	}
 	if cfg.EnableAreasAPI {
 		areas := proxy.NewAPIProxy(ctx, cfg.AreasAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 		addVersionedHandlers(router, areas, cfg.AreasAPIVersions, "/areas")

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -248,47 +248,6 @@ func TestRouterPublicAPIs(t *testing.T) {
 			verifyProxied("/images/subpath", imageAPIURL)
 		})
 
-		Convey("Given an URL to an articles subpath", func() {
-			host := "http://localhost:23200"
-			path := "/%s/articles/subpath"
-			urlPattern := host + path
-
-			Convey("And the feature flag is enabled", func() {
-				cfg.EnableArticlesAPI = true
-				for _, version := range cfg.ArticlesAPIVersions {
-					Convey("When we make a GET request using the mapped version "+version, func() {
-						w := createRouterTest(cfg, fmt.Sprintf(urlPattern, version))
-						Convey("Then the request is proxied to the articles API", func() {
-							So(w.Code, ShouldEqual, http.StatusOK)
-							verifyProxied(fmt.Sprintf(path, version), articlesAPIURL)
-						})
-					})
-				}
-
-				Convey("When we make a GET request using an unmapped version", func() {
-					version := "v9"
-					createRouterTest(cfg, fmt.Sprintf(urlPattern, version))
-					Convey("Then the request falls through to the default zebedee handler", func() {
-						verifyProxied(fmt.Sprintf(path, version), zebedeeURL)
-					})
-				})
-			})
-
-			Convey("And the feature flag is disabled", func() {
-				cfg.EnableArticlesAPI = false
-				for _, version := range cfg.ArticlesAPIVersions {
-					Convey("When we make a GET request using the mapped version "+version, func() {
-						// deliberately not configured v1 to get around legacy handle stripping it
-						w := createRouterTest(cfg, fmt.Sprintf(urlPattern, version))
-						Convey("Then it falls through to the default zebedee handler", func() {
-							So(w.Code, ShouldEqual, http.StatusOK)
-							verifyProxied(fmt.Sprintf(path, version), zebedeeURL)
-						})
-					})
-				}
-			})
-		})
-
 		Convey("Given an URL to an feedback subpath", func() {
 			host := "http://localhost:23200"
 			path := "/%s/feedback/subpath"

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -85,10 +85,6 @@ func TestRouterPublicAPIs(t *testing.T) {
 			"/topics":           topicAPIURL,
 		}
 
-		cfg.ArticlesAPIVersions = []string{"a", "b"}
-		for _, version := range cfg.ArticlesAPIVersions {
-			expectedPublicURLs["/"+version+"/articles"] = articlesAPIURL
-		}
 		cfg.FeedbackAPIVersions = []string{"aB", "bE"}
 		for _, version := range cfg.FeedbackAPIVersions {
 			expectedPublicURLs["/"+version+"/feedback"] = feedbackAPIURL

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -60,7 +60,6 @@ func TestRouterPublicAPIs(t *testing.T) {
 		searchAPIURL, _ := url.Parse(cfg.SearchAPIURL)
 		dimensionSearchAPIURL, _ := url.Parse(cfg.DimensionSearchAPIURL)
 		imageAPIURL, _ := url.Parse(cfg.ImageAPIURL)
-		articlesAPIURL, _ := url.Parse(cfg.ArticlesAPIURL)
 		feedbackAPIURL, _ := url.Parse(cfg.FeedbackAPIURL)
 		releaseCalendarAPIURL, _ := url.Parse(cfg.ReleaseCalendarAPIURL)
 		populationTypesAPIURL, _ := url.Parse(cfg.PopulationTypesAPIURL)


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
The Articles API has been removed and the readme updated to reflect this. The Articles API was created to replace existing functionality in babbage but is now being "moth-balled" because it's taken a low priority. The following ticket contains this task:

https://trello.com/c/rzIQoHXj/1383-make-articles-api-read-only

# How to review
<!--- Describe in detail how you tested your changes. -->
Check that this service no longer routes to the Articles API, that the readme looks correct, and that the tests pass.

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
