### PR TITLE
Add search scrubber api

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This service is responsible for serving a JSON-LD `@context` field on configured
 | ENABLE_AREAS_API                           | false                    | Flag to enable routing to the areas API                                                    |
 | ENABLE_CANTABULAR_METADATA_EXTRACTOR_API   | false                    | Flag to enable routing to the cantabular metadata extractor API                            |
 | ENABLE_ZEBEDEE_AUDIT                       | false                    |                                                                                            |
+| ENABLE_NLP_SEARCH_APIS                     | false                    | Flag to enable routing to the NLP search APIs                                              |
 | CONTEXT_URL                                | ""                       | A URL to the JSON-LD context file describing the APIs                                      |
 | API_POC_URL                                | "http://localhost:3000"  | A URL to the poc api                                                                       |
 | IMPORT_API_URL                             | "http://localhost:21800" | A URL to the import api                                                                    |
@@ -56,6 +57,8 @@ This service is responsible for serving a JSON-LD `@context` field on configured
 | AREAS_API_URL                              | "http://localhost:25500" | A URL to the areas API                                                                     |
 | AREAS_API_VERSIONS                         | "v1"                     | A comma-delimited string list: versions supported by the areas API                         |
 | CANTABULAR_METADATA_EXTRACTOR_API_URL      | "http://localhost:28300" | A URL to the Cantabular metadata extractor API                                             |
+| SEARCH_SCRUBBER_API_URL                    | "http://localhost:28700" | A URL to the Cantabular metadata extractor API                                             |
+| SEARCH_SCRUBBER_API_VERSIONS               | "v1"                     | A comma delimted string with a list of versions supported by search scrubber api           |
 | KAFKA_ADDR                                 | localhost:9092           | The list of kafka hosts                                                                    |
 | KAFKA_MAX_BYTES                            | 2000000                  | The maximum bytes that can be sent in an event to kafka topic                              |
 | KAFKA_VERSION                              | "1.0.2"                  | The kafka version that this service expects to connect to                                  |

--- a/config/config.go
+++ b/config/config.go
@@ -83,6 +83,9 @@ type Config struct {
 	EnableCantabularMetadataExtractorAPI bool          `envconfig:"ENABLE_CANTABULAR_METADATA_EXTRACTOR_API"`
 	CantabularMetadataExtractorAPIURL    string        `envconfig:"CANTABULAR_METADATA_API_URL"`
 	ZebedeeClientTimeout                 time.Duration `envconfig:"ZEBEDEE_CLIENT_TIMEOUT"`
+	EnableNLPSearchAPIs                  bool          `envconfig:"ENABLE_NLP_SEARCH_APIS"`
+	SearchScrubberAPIURL                 string        `envconfig:"SEARCH_SCRUBBER_API_URL"`
+	SearchScrubberAPIVersions            []string      `envconfig:"SEARCH_SCRUBBER_API_VERSIONS"`
 	Auth                                 authorisation.Config
 }
 
@@ -163,6 +166,9 @@ func Get() (*Config, error) {
 		EnableCantabularMetadataExtractorAPI: false,
 		CantabularMetadataExtractorAPIURL:    "http://localhost:28300",
 		ZebedeeClientTimeout:                 30 * time.Second,
+		EnableNLPSearchAPIs:                  true,
+		SearchScrubberAPIURL:                 "http://localhost:28700",
+		SearchScrubberAPIVersions:            []string{"v1"},
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config.go
+++ b/config/config.go
@@ -166,7 +166,7 @@ func Get() (*Config, error) {
 		EnableCantabularMetadataExtractorAPI: false,
 		CantabularMetadataExtractorAPIURL:    "http://localhost:28300",
 		ZebedeeClientTimeout:                 30 * time.Second,
-		EnableNLPSearchAPIs:                  true,
+		EnableNLPSearchAPIs:                  false,
 		SearchScrubberAPIURL:                 "http://localhost:28700",
 		SearchScrubberAPIVersions:            []string{"v1"},
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -83,6 +83,9 @@ func TestGetReturnsDefaultValues(t *testing.T) {
 			EnableCantabularMetadataExtractorAPI: false,
 			CantabularMetadataExtractorAPIURL:    "http://localhost:28300",
 			ZebedeeClientTimeout:                 30 * time.Second,
+			EnableNLPSearchAPIs:                  false,
+			SearchScrubberAPIURL:                 "http://localhost:28700",
+			SearchScrubberAPIVersions:            []string{"v1"},
 		})
 	})
 }

--- a/service/service.go
+++ b/service/service.go
@@ -195,6 +195,12 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		addTransitionalHandler(router, downloadService, "/downloads-new")
 	}
 
+	if cfg.EnableNLPSearchAPIs {
+		searchScrubberAPIProxy := proxy.NewAPIProxy(ctx, cfg.SearchScrubberAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+
+		addVersionedHandlers(router, searchScrubberAPIProxy, cfg.SearchScrubberAPIVersions, "/scrubber")
+	}
+
 	// Private APIs
 	if cfg.EnablePrivateEndpoints {
 		recipe := proxy.NewAPIProxy(ctx, cfg.RecipeAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)


### PR DESCRIPTION
### What

Added feature flagged search scrubber api routing.
The feature flag is more generic as I think it should switch on/off all 3 nlp apis when we get there. 

### How to review

Check tests pass.
Check it routes traffic to the search scrubber api when turned on. 

### Who can review

Not me. 