### PR TITLE
Re-add interceptor to filter-flex routes

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -143,6 +143,7 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 	dataset := proxy.NewAPIProxyWithOptions(ctx, cfg.DatasetAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.ContextURL, cfg.EnableV1BetaRestriction, proxy.Options{Interceptor: true})
 	filter := proxy.NewAPIProxyWithOptions(ctx, cfg.FilterAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction, proxy.Options{Interceptor: true})
 	filterFlex := proxy.NewAPIProxy(ctx, cfg.FilterFlexAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
+	filterFlexIntercepted := proxy.NewAPIProxyWithOptions(ctx, cfg.FilterFlexAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction, proxy.Options{Interceptor: true})
 	hierarchy := proxy.NewAPIProxyWithOptions(ctx, cfg.HierarchyAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction, proxy.Options{Interceptor: true})
 	search := proxy.NewAPIProxy(ctx, cfg.SearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction)
 	dimensionSearch := proxy.NewAPIProxyWithOptions(ctx, cfg.DimensionSearchAPIURL, cfg.Version, cfg.EnvironmentHost, "", cfg.EnableV1BetaRestriction, proxy.Options{Interceptor: true})
@@ -161,8 +162,8 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		addVersionedHandlers(router, feedback, cfg.FeedbackAPIVersions, "/feedback")
 	}
 
-	addTransitionalHandler(router, filterFlex, "/datasets/{dataset_id}/editions/{edition}/versions/{version}/json")
-	addTransitionalHandler(router, filterFlex, "/datasets/{dataset_id}/editions/{edition}/versions/{version}/census-observations")
+	addTransitionalHandler(router, filterFlexIntercepted, "/datasets/{dataset_id}/editions/{edition}/versions/{version}/json")
+	addTransitionalHandler(router, filterFlexIntercepted, "/datasets/{dataset_id}/editions/{edition}/versions/{version}/census-observations")
 	addTransitionalHandler(router, filterFlex, "/custom/filters")
 
 	addTransitionalHandler(router, codeList, "/code-lists")


### PR DESCRIPTION
### What

Re-add the interceptor to filter-flex routes (it turns out it does still need to be translated to change the URLS)
NB…
- This reverts the change for these routes from #211 
- The `/custom/filters` route (on line 167) was never intercepted before the refactoring so this still isn't intercepted, hence why it still uses non-intercepting proxy

### How to review

Ensure code makes sense and tests pass

### Who can review

Anyone