### PR TITLE
Add temporary debugging code to dump http headers on specific requests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -82,6 +82,12 @@ issues:
         - goconst
         - revive
         - gocritic
+
+    # Temporarily exclude linting failure of RoundTrip function
+    - path: interceptor/interceptor.go
+      linters:
+        - gocyclo
+      text: "cyclomatic complexity 25 of func .*RoundTrip"
   new: false
 
 # golangci.com configuration

--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -58,7 +58,7 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 	// This entire section is skipped when not enabled so should not impact prod if accidentally deployed
 	// Can be removed if in doubt along with global var `debugHeaders`
 	if debugHeaders {
-		//Only output headers for requests supplying the valid debugging key
+		// Only output headers for requests supplying the valid debugging key
 		q := req.URL.Query()
 		clientKey, ok := q["debug_key"]
 		if ok && clientKey[0] == os.Getenv("ROUTER_DEBUG_KEY") {

--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -47,9 +48,39 @@ var (
 	re = regexp.MustCompile(`^(.+://)(.+)(/v\d)$`)
 )
 
+var debugHeaders = os.Getenv("ROUTER_DEBUG_KEY") != "" // Temporary var to be removed when unused (default: false)
+
 // RoundTrip intercepts the response body and post processes to add the correct environment
 // host to links
 func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+
+	// Temporary debug code to dump out http headers for router refactoring work
+	// This entire section is skipped when not enabled so should not impact prod if accidentally deployed
+	// Can be removed if in doubt along with global var `debugHeaders`
+	if debugHeaders {
+		//Only output headers for requests supplying the valid debugging key
+		q := req.URL.Query()
+		clientKey, ok := q["debug_key"]
+		if ok && clientKey[0] == os.Getenv("ROUTER_DEBUG_KEY") {
+			// We don't want to log all headers in case they have sensitive data (eg. auth tokens)
+			okHeadersMap := map[string]bool{}
+			if okHeadersList := os.Getenv("ROUTER_DEBUG_HEADERS"); okHeadersList != "" {
+				for _, h := range strings.Split(okHeadersList, ",") {
+					okHeadersMap[h] = true
+				}
+			}
+			headerDump := map[string][]string{}
+			for k, v := range req.Header {
+				if okHeadersMap[k] {
+					headerDump[k] = v
+				} else {
+					headerDump[k] = []string{"**redacted**"}
+				}
+			}
+			log.Info(req.Context(), "debugging http headers", log.Data{"headers": headerDump})
+		}
+	}
+
 	// Make the request to the server
 	resp, err = t.RoundTripper.RoundTrip(req)
 	if err != nil {

--- a/interceptor/interceptor.go
+++ b/interceptor/interceptor.go
@@ -53,7 +53,6 @@ var debugHeaders = os.Getenv("ROUTER_DEBUG_KEY") != "" // Temporary var to be re
 // RoundTrip intercepts the response body and post processes to add the correct environment
 // host to links
 func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
-
 	// Temporary debug code to dump out http headers for router refactoring work
 	// This entire section is skipped when not enabled so should not impact prod if accidentally deployed
 	// Can be removed if in doubt along with global var `debugHeaders`


### PR DESCRIPTION
### What

Add temporary debugging code to dump http headers on specific requests

This will enable us to add a url parameter on specific requests and get a dump of the request's internal http request headers in the logs. For safety reasons, only the values of configured headers will be dumped out in order to prevent logging of sensitive values, eg. auth tokens. Also this functionality is only enabled when the debug key is set so causes no performance hit if unintentionally deployed to prod. 

This code is only intended to be deployed as far as staging so it can be tested with CloudFlare. 

To use, the env vars will be configured in vault…
- `ROUTER_DEBUG_KEY` = some value only know to us to stop anyone public using it (debugging disabled if blank)
- `ROUTER_DEBUG_HEADERS` = comma-separated list of headers whose values are alowed to be dumped to the logs (eg. `"X-Forwarded-For,Accept,Accept-Encoding"`

Requests can be made to trigger the debugging by adding the URL parameter `debug_key=some_value`.

NB. I had to do some jiggery-pokery with the linting config to get it to pass. This is only temporary code so no need to refactor for cyclomatic complexity. I'll remove the linting exclusion when I remove the temporary code.

### How to review

Ensure the code does as described, especially that it will be disabled by default and only apply to a very limited and specific subset of requests.

Ensure tests pass.

### Who can review

Anyone but me.