### PR TITLE
Upgrade golangci-lint to latest

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -87,6 +87,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.43.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: latest 
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ all: audit test build
 
 .PHONY: lint
 lint:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	golangci-lint run ./...
 
 .PHONY: audit


### PR DESCRIPTION
### What

The linters have been upgraded to the latest version of golangci-lint

### How to review

When future PRs are created, the pipeline will test for correct lint 

### Who can review

A member of ONS
