### PR TITLE
add a for-development flag: stops error when only 1 broker in dev (producers only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ This service is responsible for serving a JSON-LD `@context` field on configured
 | KAFKA_SEC_CLIENT_CERT                    | _unset_                  | PEM [2] for the client certificate (optional, used for client auth) [1]            |
 | KAFKA_SEC_CA_CERTS                       | _unset_                  | PEM [2] of CA cert chain if using private CA for the server cert [1]               |
 | KAFKA_SEC_SKIP_VERIFY                    | false                    | ignore server certificate issues if set to `true` [1]                              |
+| KAFKA_MIN_HEALTHY_BROKERS                | 0                        | The minimum number of healthy brokers, else app stays unhealthy [3]                |
 | AUDIT_TOPIC                              | audit                    | The kafka topic name for audit events                                              |
 | HEALTHCHECK_INTERVAL                     | 30s                      | The period of time between health checks                                           |
 | HEALTHCHECK_CRITICAL_TIMEOUT             | 90s                      | The period of time after which failing checks will result in critical global check |
@@ -82,3 +83,5 @@ Notes:
 2. PEM values are identified as those starting with `-----BEGIN`
    and can use `\n` (sic) instead of newlines (they will be converted to newlines before use).
    Any other value will be treated as a path to the given PEM file.
+
+3. the default is `0` which means "use library default" - recommended to change this _only in development_ (e.g. when running only one broker)

--- a/config/config.go
+++ b/config/config.go
@@ -56,6 +56,7 @@ type Config struct {
 	KafkaSecClientKey                    string        `envconfig:"KAFKA_SEC_CLIENT_KEY" json:"-"`
 	KafkaSecSkipVerify                   bool          `envconfig:"KAFKA_SEC_SKIP_VERIFY"`
 	KafkaMaxBytes                        int           `envconfig:"KAFKA_MAX_BYTES"`
+	KafkaMinHealthyBrokers               int           `envconfig:"KAFKA_MIN_HEALTHY_BROKERS"`
 	AuditTopic                           string        `envconfig:"AUDIT_TOPIC"`
 	SessionsAPIURL                       string        `envconfig:"SESSIONS_API_URL"`
 	EnableSessionsAPI                    bool          `envconfig:"ENABLE_SESSIONS_API"`
@@ -143,6 +144,7 @@ func Get() (*Config, error) {
 		AllowedOrigins:                       []string{"http://localhost:20000", "http://localhost:8081"},
 		AllowedMethods:                       []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodHead, http.MethodOptions},
 		KafkaMaxBytes:                        2000000,
+		KafkaMinHealthyBrokers:               0,
 		AuditTopic:                           "audit",
 		SessionsAPIURL:                       "http://localhost:24400",
 		EnableSessionsAPI:                    false,

--- a/service/initialise.go
+++ b/service/initialise.go
@@ -64,6 +64,9 @@ func (e *Init) DoGetKafkaProducer(ctx context.Context, cfg *config.Config, topic
 		Topic:           topic,
 		BrokerAddrs:     cfg.Brokers,
 	}
+	if cfg.KafkaMinHealthyBrokers > 0 {
+		pConfig.MinBrokersHealthy = &cfg.KafkaMinHealthyBrokers
+	}
 	if cfg.KafkaSecProtocol == "TLS" {
 		pConfig.SecurityConfig = kafka.GetSecurityConfig(cfg.KafkaSecCACerts, cfg.KafkaSecClientCert, cfg.KafkaSecClientKey, cfg.KafkaSecSkipVerify)
 	}


### PR DESCRIPTION
### What

To stop my dev-env from melting, I'm running only one kafka broker.

This causes the kafka lib to complain - it needs a min of 2 healthy brokers for producers -
and the app never gets healthy.

So, this is a env var to allow us to change that minimum healthy brokers to 1.

Only to be used in dev-env.

### How to review

Use with or without `KAFKA_MIN_HEALTHY_BROKERS`

### Who can review

!me
