### PR TITLE
use version config instead of /v1

### DIFF
--- a/middleware/beta.go
+++ b/middleware/beta.go
@@ -13,7 +13,7 @@ const (
 )
 
 // BetaAPIHandler will return a 404 where enforceBetaRoutes is true and the request is aimed at a non beta domain
-func BetaAPIHandler(enableBetaRestriction bool, h http.Handler) http.Handler {
+func BetaAPIHandler(enableBetaRestriction bool, h http.Handler, version string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if enableBetaRestriction && !isInternalTraffic(r) && !isBetaDomain(r) {
 			log.Warn(r.Context(), "beta endpoint requested via a non beta domain, returning 404",
@@ -21,7 +21,7 @@ func BetaAPIHandler(enableBetaRestriction bool, h http.Handler) http.Handler {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
-		r.Header.Add("X-Forwarded-Path-Prefix", "/v1")
+		r.Header.Add("X-Forwarded-Path-Prefix", version)
 		h.ServeHTTP(w, r)
 	})
 }

--- a/middleware/beta_test.go
+++ b/middleware/beta_test.go
@@ -10,11 +10,12 @@ import (
 
 var (
 	dummyHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {})
+	version      = "v1"
 )
 
 func TestBetaHandler(t *testing.T) {
 	Convey("beta handler should wrap another handler", t, func() {
-		wrapped := BetaAPIHandler(true, dummyHandler)
+		wrapped := BetaAPIHandler(true, dummyHandler, version)
 		So(wrapped, ShouldHaveSameTypeAs, dummyHandler)
 	})
 
@@ -26,7 +27,7 @@ func TestBetaHandler(t *testing.T) {
 			req.Host = "api.beta"
 
 			w := httptest.NewRecorder()
-			wrapped := BetaAPIHandler(true, dummyHandler)
+			wrapped := BetaAPIHandler(true, dummyHandler, version)
 
 			wrapped.ServeHTTP(w, req)
 			So(w.Code, ShouldEqual, 200)
@@ -39,7 +40,7 @@ func TestBetaHandler(t *testing.T) {
 			req.Host = "api.not.beta"
 
 			w := httptest.NewRecorder()
-			wrapped := BetaAPIHandler(true, dummyHandler)
+			wrapped := BetaAPIHandler(true, dummyHandler, version)
 
 			wrapped.ServeHTTP(w, req)
 			So(w.Code, ShouldEqual, 404)
@@ -52,7 +53,7 @@ func TestBetaHandler(t *testing.T) {
 			req.Host = "10.201.4.85:80"
 
 			w := httptest.NewRecorder()
-			wrapped := BetaAPIHandler(true, dummyHandler)
+			wrapped := BetaAPIHandler(true, dummyHandler, version)
 
 			wrapped.ServeHTTP(w, req)
 			So(w.Code, ShouldEqual, 200)
@@ -65,7 +66,7 @@ func TestBetaHandler(t *testing.T) {
 			req.Host = "somehost:20100"
 
 			w := httptest.NewRecorder()
-			wrapped := BetaAPIHandler(true, dummyHandler)
+			wrapped := BetaAPIHandler(true, dummyHandler, version)
 
 			wrapped.ServeHTTP(w, req)
 			So(w.Code, ShouldEqual, 404)
@@ -78,7 +79,7 @@ func TestBetaHandler(t *testing.T) {
 			req.Host = "10.201.4.85"
 
 			w := httptest.NewRecorder()
-			wrapped := BetaAPIHandler(true, dummyHandler)
+			wrapped := BetaAPIHandler(true, dummyHandler, version)
 
 			wrapped.ServeHTTP(w, req)
 			So(w.Code, ShouldEqual, 200)
@@ -91,7 +92,7 @@ func TestBetaHandler(t *testing.T) {
 			req.Host = localhost
 
 			w := httptest.NewRecorder()
-			wrapped := BetaAPIHandler(true, dummyHandler)
+			wrapped := BetaAPIHandler(true, dummyHandler, version)
 
 			wrapped.ServeHTTP(w, req)
 			So(w.Code, ShouldEqual, 200)
@@ -104,7 +105,7 @@ func TestBetaHandler(t *testing.T) {
 			req.Host = "localhost:20300"
 
 			w := httptest.NewRecorder()
-			wrapped := BetaAPIHandler(true, dummyHandler)
+			wrapped := BetaAPIHandler(true, dummyHandler, version)
 
 			wrapped.ServeHTTP(w, req)
 			So(w.Code, ShouldEqual, 200)
@@ -119,7 +120,7 @@ func TestBetaHandler(t *testing.T) {
 			req.Host = "api.not.beta"
 
 			w := httptest.NewRecorder()
-			wrapped := BetaAPIHandler(false, dummyHandler)
+			wrapped := BetaAPIHandler(false, dummyHandler, version)
 
 			wrapped.ServeHTTP(w, req)
 			So(w.Code, ShouldEqual, 200)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -75,5 +75,5 @@ func (p *APIProxy) Handle(w http.ResponseWriter, r *http.Request) {
 func (p *APIProxy) LegacyHandle(w http.ResponseWriter, r *http.Request) {
 	r.URL.Path = strings.Replace(r.URL.Path, "/v1", "", 1)
 
-	middleware.BetaAPIHandler(p.enableBetaRestriction, p.proxy).ServeHTTP(w, r)
+	middleware.BetaAPIHandler(p.enableBetaRestriction, p.proxy, p.Version).ServeHTTP(w, r)
 }


### PR DESCRIPTION
### What

Use the `version` config from the proxy instead of manually typing `/v1`

### How to review

check changes are ok
ci passes

### Who can review

Anyone
