### PR TITLE
Feature/remove api poc

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "go.diagnostic.vulncheck": "Imports"
+}

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ service need to be updated to point to a new file location or not.
 | ENABLE_ZEBEDEE_AUDIT                     | false                    |                                                                                                |
 | ENABLE_NLP_SEARCH_APIS                   | false                    | Flag to enable routing to the NLP search APIs                                                  |
 | CONTEXT_URL                              | ""                       | A URL to the JSON-LD context file describing the APIs                                          |
-| API_POC_URL                              | "http://localhost:3000"  | A URL to the poc api                                                                           |
 | IMPORT_API_URL                           | "http://localhost:21800" | A URL to the import api                                                                        |
 | DATASET_API_URL                          | "http://localhost:22000" | A URL to the dataset api                                                                       |
 | FILTER_API_URL                           | "http://localhost:22100" | A URL to the filter api                                                                        |

--- a/README.md
+++ b/README.md
@@ -3,11 +3,6 @@
 A service which routes API requests to the correct services. In the future this may add additional header information
 which will be used by the services.
 
-## JSON-LD
-
-This service is responsible for serving a JSON-LD `@context` field on configured API routes. In order to update the
-JSON-LD files, follow [this guide](JSONLD.md). Once the files have been updated, consider if the secrets for this
-service need to be updated to point to a new file location or not.
 
 ## Configuration
 

--- a/config/config.go
+++ b/config/config.go
@@ -39,7 +39,6 @@ type Config struct {
 	PermissionsAPIURL                    string         `envconfig:"PERMISSIONS_API_URL"`
 	PermissionsAPIVersions               []string       `envconfig:"PERMISSIONS_API_VERSIONS"`
 	EnvironmentHost                      string         `envconfig:"ENV_HOST"`
-	APIPocURL                            string         `envconfig:"API_POC_URL"`
 	GracefulShutdown                     time.Duration  `envconfig:"SHUTDOWN_TIMEOUT"`
 	AllowedMethods                       []string       `envconfig:"ALLOWED_METHODS"`
 	AllowedHeaders                       []string       `envconfig:"ALLOWED_HEADERS"`
@@ -123,7 +122,6 @@ func Get() (*Config, error) {
 		IdentityAPIVersions:                  []string{"v1"},
 		PermissionsAPIURL:                    "http://localhost:25400",
 		PermissionsAPIVersions:               []string{"v1"},
-		APIPocURL:                            "http://localhost:3000",
 		EnvironmentHost:                      "http://localhost:23200",
 		GracefulShutdown:                     5 * time.Second,
 		HealthCheckInterval:                  30 * time.Second,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -43,7 +43,6 @@ func TestGetReturnsDefaultValues(t *testing.T) {
 			PermissionsAPIVersions:               []string{"v1"},
 			SearchAPIURL:                         "http://localhost:23900",
 			DimensionSearchAPIURL:                "http://localhost:23100",
-			APIPocURL:                            "http://localhost:3000",
 			EnvironmentHost:                      "http://localhost:23200",
 			GracefulShutdown:                     5 * time.Second,
 			HealthCheckInterval:                  30 * time.Second,

--- a/service/service.go
+++ b/service/service.go
@@ -258,13 +258,6 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		}
 	}
 
-	// Legacy API
-	poc := proxy.NewAPIProxy(ctx, cfg.APIPocURL, "", cfg.EnvironmentHost, false)
-	addLegacyHandler(router, poc, "/ops")
-	addLegacyHandler(router, poc, "/dataset")
-	addLegacyHandler(router, poc, "/timeseries")
-	addLegacyHandler(router, poc, "/search")
-
 	zebedee := proxy.NewAPIProxy(ctx, cfg.ZebedeeURL, cfg.Version, cfg.EnvironmentHost, false)
 	router.NotFoundHandler = http.HandlerFunc(zebedee.LegacyHandle)
 
@@ -281,11 +274,6 @@ func addVersionedHandlers(router *mux.Router, apiProxy *proxy.APIProxy, versions
 func addTransitionalHandler(router *mux.Router, apiProxy *proxy.APIProxy, path string) {
 	// Proxy any request after the path given to the target address
 	router.HandleFunc(fmt.Sprintf("/%s"+path+"{rest:$|/.*}", apiProxy.Version), apiProxy.LegacyHandle)
-}
-
-func addLegacyHandler(router *mux.Router, apiProxy *proxy.APIProxy, path string) {
-	// Proxy any request after the path given to the target address
-	router.HandleFunc(path+"{rest:.*}", apiProxy.LegacyHandle)
 }
 
 // Close gracefully shuts the service down in the required order, with timeout

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -636,49 +636,6 @@ func TestRouterPrivateAPIs(t *testing.T) {
 	})
 }
 
-func TestRouterLegacyAPIs(t *testing.T) {
-	Convey("Given an api router and proxies with all legacy endpoints available", t, func() {
-		cfg, err := config.Get()
-		So(err, ShouldBeNil)
-
-		apiPocURL, err := url.Parse(cfg.APIPocURL)
-		So(err, ShouldBeNil)
-
-		expectedLegacyURLs := map[string]*url.URL{
-			"/ops":        apiPocURL,
-			"/dataset":    apiPocURL,
-			"/timeseries": apiPocURL,
-			"/search":     apiPocURL,
-		}
-
-		resetProxyMocksWithExpectations(expectedLegacyURLs)
-
-		Convey("An un-versioned request to an ops path is proxied to pocAPIURL", func() {
-			w := createRouterTest(cfg, "http://localhost:23200/ops")
-			So(w.Code, ShouldEqual, http.StatusOK)
-			verifyProxied("/ops", apiPocURL)
-		})
-
-		Convey("An un-versioned request to a dataset path is proxied to pocAPIURL", func() {
-			w := createRouterTest(cfg, "http://localhost:23200/dataset")
-			So(w.Code, ShouldEqual, http.StatusOK)
-			verifyProxied("/dataset", apiPocURL)
-		})
-
-		Convey("An un-versioned request to a timeseries path is proxied to pocAPIURL", func() {
-			w := createRouterTest(cfg, "http://localhost:23200/timeseries")
-			So(w.Code, ShouldEqual, http.StatusOK)
-			verifyProxied("/timeseries", apiPocURL)
-		})
-
-		Convey("An un-versioned request to a search path is proxied to pocAPIURL", func() {
-			w := createRouterTest(cfg, "http://localhost:23200/search")
-			So(w.Code, ShouldEqual, http.StatusOK)
-			verifyProxied("/search", apiPocURL)
-		})
-	})
-}
-
 func assertOnlyThisURLIsCalled(expectedURL *url.URL) {
 	for urlToCheck, pxy := range registeredProxies {
 		if urlToCheck == *expectedURL {


### PR DESCRIPTION
### What

Removed dp-apipoc-server from router as is now deprecated

### How to review

Check got it all
Run tests
Run service and see that those endpoints now fall through to zebedee

### Who can review

Not me. 