### PR TITLE
Remove sessions API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ which will be used by the services.
 | ENABLE_OBSERVATION_API                   | false                      |                                                                                                |
 | ENABLE_PRIVATE_ENDPOINTS                 | true                       | If private endpoints should be routed                                                          |
 | ENABLE_V1_BETA_RESTRICTION               | false                      |                                                                                                |
-| ENABLE_SESSIONS_API                      | false                      |                                                                                                |
 | ENABLE_RELEASE_CALENDAR_API              | false                      | Flag to enable routing to the release calendar API                                             |
 | ENABLE_CANTABULAR_METADATA_EXTRACTOR_API | false                      | Flag to enable routing to the cantabular metadata extractor API                                |
 | ENABLE_ZEBEDEE_AUDIT                     | false                      |                                                                                                |
@@ -30,7 +29,6 @@ which will be used by the services.
 | HIERARCHY_API_URL                        | "<http://localhost:22600>" | A URL to the hierarchy api                                                                     |
 | SEARCH_API_URL                           | "<http://localhost:23900>" | A URL to the search api                                                                        |
 | DIMENSION_SEARCH_API_URL                 | "<http://localhost:23100>" | A URL to the dimension search api                                                              |
-| SESSIONS_API_URL                         | "<http://localhost:24400>" | A URL to the sessions api                                                                      |
 | OBSERVATION_API_URL                      | "<http://localhost:24500>" | A URL to the observation api                                                                   |
 | IMAGE_API_URL                            | "<http://localhost:24700>" | A URL to the image api                                                                         |
 | UPLOAD_SERVICE_API_URL:                  | "<http://localhost:25100>" | A URL to the upload service api                                                                |

--- a/config/config.go
+++ b/config/config.go
@@ -55,8 +55,6 @@ type Config struct {
 	KafkaMaxBytes                        int            `envconfig:"KAFKA_MAX_BYTES"`
 	KafkaMinHealthyBrokers               int            `envconfig:"KAFKA_MIN_HEALTHY_BROKERS"`
 	AuditTopic                           string         `envconfig:"AUDIT_TOPIC"`
-	SessionsAPIURL                       string         `envconfig:"SESSIONS_API_URL"`
-	EnableSessionsAPI                    bool           `envconfig:"ENABLE_SESSIONS_API"`
 	TopicAPIURL                          string         `envconfig:"TOPIC_API_URL"`
 	EnableFeedbackAPI                    bool           `envconfig:"ENABLE_FEEDBACK_API"`
 	FeedbackAPIURL                       string         `envconfig:"FEEDBACK_API_URL"`
@@ -136,8 +134,6 @@ func Get() (*Config, error) {
 		KafkaMaxBytes:                        2000000,
 		KafkaMinHealthyBrokers:               0,
 		AuditTopic:                           "audit",
-		SessionsAPIURL:                       "http://localhost:24400",
-		EnableSessionsAPI:                    false,
 		TopicAPIURL:                          "http://localhost:25300",
 		FeedbackAPIURL:                       "http://localhost:28600",
 		EnableFeedbackAPI:                    false,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -54,8 +54,6 @@ func TestGetReturnsDefaultValues(t *testing.T) {
 			AllowedOrigins:                       []string{"http://localhost:20000", "http://localhost:8081"},
 			AllowedMethods:                       []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodHead, http.MethodOptions},
 			AuditTopic:                           "audit",
-			SessionsAPIURL:                       "http://localhost:24400",
-			EnableSessionsAPI:                    false,
 			TopicAPIURL:                          "http://localhost:25300",
 			FeedbackAPIURL:                       "http://localhost:28600",
 			EnableFeedbackAPI:                    false,

--- a/service/service.go
+++ b/service/service.go
@@ -240,12 +240,6 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 		addVersionedHandlers(router, permissionsAPIProxy, cfg.PermissionsAPIVersions, "/roles")
 		addVersionedHandlers(router, permissionsAPIProxy, cfg.PermissionsAPIVersions, "/permissions-bundle")
 
-		// Feature flag for Sessions API
-		if cfg.EnableSessionsAPI {
-			session := proxy.NewAPIProxy(ctx, cfg.SessionsAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.EnableV1BetaRestriction)
-			addTransitionalHandler(router, session, "/sessions")
-		}
-
 		// Feature flag for Files API
 		if cfg.EnableFilesAPI {
 			addTransitionalHandler(router, uploadServiceAPI, "/upload-new")


### PR DESCRIPTION
### What

Removed code for Sessions API as now defunct: https://github.com/ONSdigital/dp-sessions-api

### How to review

Check looks ok, removed only unnecessary code. 

### Who can review

Not me. 