### PR TITLE
registered /dataset-editions into service file and updated unit test

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -190,6 +190,8 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 
 	addTransitionalHandler(router, codeList, "/code-lists")
 	addTransitionalHandler(router, dataset, "/datasets")
+	addTransitionalHandler(router, dataset, "/dataset-editions")
+
 	addTransitionalHandler(router, filter, "/filters")
 	addTransitionalHandler(router, filter, "/filter-outputs")
 	addTransitionalHandler(router, hierarchy, "/hierarchies")

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -71,6 +71,7 @@ func TestRouterPublicAPIs(t *testing.T) {
 			"/datasets/{dataset_id}/editions/{edition}/versions/{version}/observations":        observationAPIURL,
 			"/datasets/{dataset_id}/editions/{edition}/versions/{version}/json":                filterFlexAPIURL,
 			"/datasets/{dataset_id}/editions/{edition}/versions/{version}/census-observations": filterFlexAPIURL,
+			"/dataset-editions": datasetAPIURL,
 			"/custom/filters":   filterFlexAPIURL,
 			"/filters":          filterAPIURL,
 			"/filter-outputs":   filterAPIURL,
@@ -118,6 +119,12 @@ func TestRouterPublicAPIs(t *testing.T) {
 				verifyProxied("/datasets", datasetAPIURL)
 			})
 
+			Convey("A request to dataset-editions path succeeds and is proxied to datasetAPIURL", func() {
+				w := createRouterTest(cfg, "http://localhost:23200/v1/dataset-editions")
+				So(w.Code, ShouldEqual, http.StatusOK)
+				verifyProxied("/dataset-editions", datasetAPIURL)
+			})
+
 			Convey("A request to dataset edition path succeeds and is proxied to datasetAPIURL", func() {
 				w := createRouterTest(cfg, "http://localhost:23200/v1/datasets/cpih012/editions/123")
 				So(w.Code, ShouldEqual, http.StatusOK)
@@ -144,6 +151,12 @@ func TestRouterPublicAPIs(t *testing.T) {
 				w := createRouterTest(cfg, "http://localhost:23200/v1/datasets")
 				So(w.Code, ShouldEqual, http.StatusOK)
 				verifyProxied("/datasets", datasetAPIURL)
+			})
+
+			Convey("A request to dataset-editions path succeeds and is proxied to datasetAPIURL", func() {
+				w := createRouterTest(cfg, "http://localhost:23200/v1/dataset-editions")
+				So(w.Code, ShouldEqual, http.StatusOK)
+				verifyProxied("/dataset-editions", datasetAPIURL)
 			})
 
 			Convey("A request to dataset edition path succeeds and is proxied to datasetAPIURL", func() {


### PR DESCRIPTION
### What
- registered /dataset-editions into the dp-api-router
- Updated unit tests

### How to review
- When a request is made to the GET /dataset-editions endpoint via the api-router in publishing then a 200 response is returned with a list of items.
- When a request is made to the GET /dataset-editions endpoint via the api-router in web then a 404 response is returned.
- (make sure to set the state param with the request ie:/dataset-editions?state=created)

### Who can review
anyone