### PR TITLE
Release/2.29.0

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -78,6 +78,7 @@ type Config struct {
 	BerlinAPIVersions                    []string       `envconfig:"BERLIN_API_VERSIONS"`
 	EnableRedirectAPI                    bool           `envconfig:"ENABLE_REDIRECT_API"`
 	RedirectAPIURL                       string         `envconfig:"REDIRECT_API_URL"`
+	RedirectAPIVersions                  []string       `envconfig:"REDIRECT_API_VERSIONS"`
 	HTTPWriteTimeout                     *time.Duration `envconfig:"HTTP_WRITE_TIMEOUT"`
 	OTExporterOTLPEndpoint               string         `envconfig:"OTEL_EXPORTER_OTLP_ENDPOINT"`
 	OTServiceName                        string         `envconfig:"OTEL_SERVICE_NAME"`
@@ -158,6 +159,7 @@ func Get() (*Config, error) {
 		BerlinAPIVersions:                    []string{"v1"},
 		EnableRedirectAPI:                    false,
 		RedirectAPIURL:                       "http://localhost:29900",
+		RedirectAPIVersions:                  []string{"v1"},
 		HTTPWriteTimeout:                     nil,
 		OTExporterOTLPEndpoint:               "localhost:4317",
 		OTServiceName:                        "dp-api-router",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -76,6 +76,7 @@ func TestGetReturnsDefaultValues(t *testing.T) {
 			BerlinAPIURL:                         "http://localhost:28900",
 			BerlinAPIVersions:                    []string{"v1"},
 			RedirectAPIURL:                       "http://localhost:29900",
+			RedirectAPIVersions:                  []string{"v1"},
 			HTTPWriteTimeout:                     nil,
 			OTExporterOTLPEndpoint:               "localhost:4317",
 			OTServiceName:                        "dp-api-router",

--- a/service/service.go
+++ b/service/service.go
@@ -254,8 +254,8 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 
 		// Feature flag for Redirect API
 		if cfg.EnableRedirectAPI {
-			redirect := proxy.NewAPIProxy(ctx, cfg.RedirectAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.EnableV1BetaRestriction)
-			addTransitionalHandler(router, redirect, "/redirects")
+			redirectAPIProxy := proxy.NewAPIProxy(ctx, cfg.RedirectAPIURL, cfg.Version, cfg.EnvironmentHost, cfg.EnableV1BetaRestriction)
+			addVersionedHandlers(router, redirectAPIProxy, cfg.RedirectAPIVersions, "/redirects")
 		}
 
 		// Feature flag for Bundle API

--- a/service/service.go
+++ b/service/service.go
@@ -190,6 +190,8 @@ func CreateRouter(ctx context.Context, cfg *config.Config) *mux.Router {
 
 	addTransitionalHandler(router, codeList, "/code-lists")
 	addTransitionalHandler(router, dataset, "/datasets")
+	addTransitionalHandler(router, dataset, "/dataset-editions")
+
 	addTransitionalHandler(router, filter, "/filters")
 	addTransitionalHandler(router, filter, "/filter-outputs")
 	addTransitionalHandler(router, hierarchy, "/hierarchies")

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -460,6 +460,10 @@ func TestRouterPrivateAPIs(t *testing.T) {
 			expectedPrivateURLs[fmt.Sprintf("/%s/permissions-bundle", version)] = permissionsAPIURL
 		}
 
+		for _, version := range cfg.RedirectAPIVersions {
+			expectedPrivateURLs[fmt.Sprintf("/%s/redirects", version)] = redirectAPIURL
+		}
+
 		resetProxyMocksWithExpectations(expectedPrivateURLs)
 
 		Convey("and private endpoints enabled by configuration", func() {
@@ -618,13 +622,13 @@ func TestRouterPrivateAPIs(t *testing.T) {
 				Convey("Then a request to the redirects path is proxied to the redirectAPIURL", func() {
 					w := createRouterTest(cfg, "http://localhost:23200/v1/redirects")
 					So(w.Code, ShouldEqual, http.StatusOK)
-					verifyProxied("/redirects", redirectAPIURL)
+					verifyProxied("/v1/redirects", redirectAPIURL)
 				})
 
 				Convey("Then a request to the redirects subpath is proxied to the redirectAPIURL", func() {
 					w := createRouterTest(cfg, "http://localhost:23200/v1/redirects/subpath")
 					So(w.Code, ShouldEqual, http.StatusOK)
-					verifyProxied("/redirects/subpath", redirectAPIURL)
+					verifyProxied("/v1/redirects/subpath", redirectAPIURL)
 				})
 			})
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -71,6 +71,7 @@ func TestRouterPublicAPIs(t *testing.T) {
 			"/datasets/{dataset_id}/editions/{edition}/versions/{version}/observations":        observationAPIURL,
 			"/datasets/{dataset_id}/editions/{edition}/versions/{version}/json":                filterFlexAPIURL,
 			"/datasets/{dataset_id}/editions/{edition}/versions/{version}/census-observations": filterFlexAPIURL,
+			"/dataset-editions": datasetAPIURL,
 			"/custom/filters":   filterFlexAPIURL,
 			"/filters":          filterAPIURL,
 			"/filter-outputs":   filterAPIURL,
@@ -118,6 +119,12 @@ func TestRouterPublicAPIs(t *testing.T) {
 				verifyProxied("/datasets", datasetAPIURL)
 			})
 
+			Convey("A request to dataset-editions path succeeds and is proxied to datasetAPIURL", func() {
+				w := createRouterTest(cfg, "http://localhost:23200/v1/dataset-editions")
+				So(w.Code, ShouldEqual, http.StatusOK)
+				verifyProxied("/dataset-editions", datasetAPIURL)
+			})
+
 			Convey("A request to dataset edition path succeeds and is proxied to datasetAPIURL", func() {
 				w := createRouterTest(cfg, "http://localhost:23200/v1/datasets/cpih012/editions/123")
 				So(w.Code, ShouldEqual, http.StatusOK)
@@ -144,6 +151,12 @@ func TestRouterPublicAPIs(t *testing.T) {
 				w := createRouterTest(cfg, "http://localhost:23200/v1/datasets")
 				So(w.Code, ShouldEqual, http.StatusOK)
 				verifyProxied("/datasets", datasetAPIURL)
+			})
+
+			Convey("A request to dataset-editions path succeeds and is proxied to datasetAPIURL", func() {
+				w := createRouterTest(cfg, "http://localhost:23200/v1/dataset-editions")
+				So(w.Code, ShouldEqual, http.StatusOK)
+				verifyProxied("/dataset-editions", datasetAPIURL)
 			})
 
 			Convey("A request to dataset edition path succeeds and is proxied to datasetAPIURL", func() {


### PR DESCRIPTION
### What

[registered /dataset-editions into service file and updated unit test](https://github.com/ONSdigital/dp-api-router/commit/f51d2ca15f40c8fe611614c169d5abcafe6c5312)
[Switch redirect API to versioned handler](https://github.com/ONSdigital/dp-api-router/commit/2ec9ea86f10162ac4acd3809cc867079c9c2af0c)

### How to review

check if the changes are ready for release

### Who can review

anyone