### PR TITLE
Add Deprecation Config for /data Endpoints

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -162,7 +162,7 @@ func Get() (*Config, error) {
 		OTExporterOTLPEndpoint:               "localhost:4317",
 		OTServiceName:                        "dp-api-router",
 		OTBatchTimeout:                       time.Second * 5,
-		DeprecationConfigFilePath:            "",
+		DeprecationConfigFilePath:            "[{\"paths\":[\"/data\"],\"date\":\"2025-10-14T00:00:00Z\",\"sunset\":\"2026-01-31\",\"link\":\"https://developer.ons.gov.uk/retirement/\",\"msg\":\"As we progress towards a new website platform, this legacy endpoint will be decommissioned on 31/01/2026.\"}]",
 		OtelEnabled:                          false,
 		EnableBundleAPI:                      false,
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -80,7 +80,7 @@ func TestGetReturnsDefaultValues(t *testing.T) {
 			OTExporterOTLPEndpoint:               "localhost:4317",
 			OTServiceName:                        "dp-api-router",
 			OTBatchTimeout:                       5 * time.Second,
-			DeprecationConfigFilePath:            "",
+			DeprecationConfigFilePath:            "[{\"paths\":[\"/data\"],\"date\":\"2025-10-14T00:00:00Z\",\"sunset\":\"2026-01-31\",\"link\":\"https://developer.ons.gov.uk/retirement/\",\"msg\":\"As we progress towards a new website platform, this legacy endpoint will be decommissioned on 31/01/2026.\"}]",
 		})
 	})
 }


### PR DESCRIPTION
### What

Jira ticket: https://officefornationalstatistics.atlassian.net/jira/software/c/projects/DIS/boards/1824?selectedIssue=DIS-3241

The deprecation config has been added to activate the deprecation of editorial /data endpoints (i.e. /data endpoints in articles, bulletins, and compendia) in preparation for the move to the new website platform.

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
